### PR TITLE
Make dns_challenge.config sensitive to prevent AWS Secret on terraform output result

### DIFF
--- a/plugin/providers/acme/acme_structure.go
+++ b/plugin/providers/acme/acme_structure.go
@@ -143,6 +143,7 @@ func certificateSchema() map[string]*schema.Schema {
 						Type:         schema.TypeMap,
 						Optional:     true,
 						ValidateFunc: validateDNSChallengeConfig,
+						Sensitive: true,
 					},
 				},
 			},

--- a/plugin/providers/acme/acme_structure.go
+++ b/plugin/providers/acme/acme_structure.go
@@ -143,7 +143,7 @@ func certificateSchema() map[string]*schema.Schema {
 						Type:         schema.TypeMap,
 						Optional:     true,
 						ValidateFunc: validateDNSChallengeConfig,
-						Sensitive: true,
+						Sensitive:    true,
 					},
 				},
 			},


### PR DESCRIPTION
This commit prevents the following when executing terraform plan or apply:

```
+ module.group1_cdn_certificate.acme_certificate.certificate
      id:                                                           <computed>
      account_key_pem:                                              <sensitive>
      account_ref:                                                  <computed>
      certificate_domain:                                           <computed>
      certificate_pem:                                              <computed>
      certificate_url:                                              <computed>
      common_name:                                                  "www.example.com"
      dns_challenge.#:                                              "1"
      dns_challenge.11111111111111.config.%:                        "3"
      dns_challenge.11111111111111.config.AWS_ACCESS_KEY_ID:        "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      dns_challenge.11111111111111.config.AWS_DEFAULT_REGION:       "us-east-1"
      dns_challenge.11111111111111.config.AWS_SECRET_ACCESS_KEY:    "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      dns_challenge.3453080880.provider:                            "route53"
      http_challenge_port:                                          "80"
      issuer_pem:                                                   <computed>
      key_type:                                                     "2048"
      min_days_remaining:                                           "7"
      must_staple:                                                  "false"
      private_key_pem:                                              <computed>
      registration_url:                                             "${acme_registration.reg.id}"
      server_url:                                                   "https://acme-v01.api.letsencrypt.org/directory"
      tls_challenge_port:                                           "443"
```
Changing it to this:
```
+ module.group1_cdn_certificate.acme_certificate.certificate
      id:                                                           <computed>
      account_key_pem:                                              <sensitive>
      account_ref:                                                  <computed>
      certificate_domain:                                           <computed>
      certificate_pem:                                              <computed>
      certificate_url:                                              <computed>
      common_name:                                                  "www.example.com"
      dns_challenge.#:                                              "1"
      dns_challenge.11111111111111.config.%:                        <sensitive>
      dns_challenge.11111111111111.config.AWS_ACCESS_KEY_ID:        <sensitive>
      dns_challenge.11111111111111.config.AWS_DEFAULT_REGION:       <sensitive>
      dns_challenge.11111111111111.config.AWS_SECRET_ACCESS_KEY:    <sensitive>
      dns_challenge.3453080880.provider:                            "route53"
      http_challenge_port:                                          "80"
      issuer_pem:                                                   <computed>
      key_type:                                                     "2048"
      min_days_remaining:                                           "7"
      must_staple:                                                  "false"
      private_key_pem:                                              <computed>
      registration_url:                                             "${acme_registration.reg.id}"
      server_url:                                                   "https://acme-v01.api.letsencrypt.org/directory"
      tls_challenge_port:                                           "443"
```

While making it harder to troubleshoot, it doesn't compromise the credentials.

Ideally, only the `dns_challenge.11111111111111.config.AWS_SECRET_ACCESS_KEY` value would be obfuscated, but this is as far as my GO "goes.

Regards