### PR TITLE
Handle already revoked certificates gracefully

### DIFF
--- a/plugin/providers/acme/resource_acme_certificate.go
+++ b/plugin/providers/acme/resource_acme_certificate.go
@@ -168,7 +168,10 @@ func resourceACMECertificateDelete(d *schema.ResourceData, meta interface{}) err
 	if ok {
 		err = client.RevokeCertificate([]byte(cert.(string)))
 		if err != nil {
-			return err
+			// Ignore conflict (409) responses, as certificate is already revoked.
+			if rerr, ok := err.(acme.RemoteError); !ok || rerr.StatusCode != 409 {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Attempting to revoke an already revoked certificate will result in the
server responding with a status code of 409. This change, ensures that
this scenario is handled gracefully.

Resolves: #30