### PR TITLE
Improve azure dns challenge configuration

### DIFF
--- a/plugin/providers/acme/acme_structure.go
+++ b/plugin/providers/acme/acme_structure.go
@@ -484,6 +484,15 @@ func parsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
 	return certificates, nil
 }
 
+// helper function to map environment variables if set
+func mapEnvironmentVariableValues(keyMapping map[string]string) {
+	for key := range keyMapping {
+		if value, ok := os.LookupEnv(key); ok {
+			os.Setenv(keyMapping[key], value)
+		}
+	}
+}
+
 // setDNSChallenge takes an *acme.Client and the DNS challenge complex
 // structure as a map[string]interface{}, and configues the client to only
 // allow a DNS challenge with the configured provider.
@@ -509,6 +518,14 @@ func setDNSChallenge(client *acme.Client, m map[string]interface{}) error {
 	// lego/providers/dns/dns_providers.go
 	switch providerName {
 	case "azure":
+		// map terraform provider environment variables if present
+		mapEnvironmentVariableValues(map[string]string{
+			"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
+			"ARM_CLIENT_SECRET":   "AZURE_CLIENT_SECRET",
+			"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
+			"ARM_TENANT_ID":       "AZURE_TENANT_ID",
+			"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
+		})
 		provider, err = azure.NewDNSProvider()
 	case "auroradns":
 		provider, err = auroradns.NewDNSProvider()

--- a/plugin/providers/acme/acme_structure_test.go
+++ b/plugin/providers/acme/acme_structure_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
@@ -442,5 +443,23 @@ func TestACME_validateDNSChallengeConfig_invalid(t *testing.T) {
 	_, errs := validateDNSChallengeConfig(s, "config")
 	if len(errs) < 1 {
 		t.Fatalf("should have given an error")
+	}
+}
+
+func TestACME_mapEnvironmentVariableValues(t *testing.T) {
+	oldFoo := os.Getenv("ACME_ENV_TEST_FOO")
+	oldBar := os.Getenv("ACME_ENV_TEST_BAR")
+	defer os.Setenv("ACME_ENV_TEST_FOO", oldFoo)
+	defer os.Setenv("ACME_ENV_TEST_BAR", oldBar)
+
+	expected := "test"
+	os.Setenv("ACME_ENV_TEST_FOO", expected)
+	mapEnvironmentVariableValues(map[string]string{
+		"ACME_ENV_TEST_FOO": "ACME_ENV_TEST_BAR",
+	})
+
+	actual := os.Getenv("ACME_ENV_TEST_BAR")
+	if expected != actual {
+		t.Fatalf("expected ACME_ENV_TEST_BAR to be %q, got %q", expected, actual)
 	}
 }


### PR DESCRIPTION
The azurerm terraform provider prefixes client configuration variables
with ARM whereas lego expects configuration to be prefixed by AZURE.
This change allows transparent mapping of these variables in scenarios
where this is used alongside the azurerm provider as it allows for a
better user experience.