### PR TITLE
fix: add a "zones" field to fix multi DNS challenge certificates

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -4,8 +4,8 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/go-acme/lego/v3/certificate"
 	"github.com/go-acme/lego/v3/challenge"
@@ -81,10 +81,10 @@ func resourceACMECertificateV4() *schema.Resource {
 							Required: true,
 						},
 						"zones": {
-							Type:          schema.TypeSet,
-							Optional:      true,
-							Elem:          &schema.Schema{Type: schema.TypeString},
-							Set:           schema.HashString,
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
 						},
 						"config": {
 							Type:         schema.TypeMap,
@@ -283,7 +283,7 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 			dnsProvider.provider = p
 
 			m := v.(map[string]interface{})
-			if z, ok :=  m["zones"]; ok && len(z.(*schema.Set).List()) > 0 {
+			if z, ok := m["zones"]; ok && len(z.(*schema.Set).List()) > 0 {
 				dnsProvider.zones = stringSlice(z.(*schema.Set).List())
 			} else {
 				if zonesRequired == true {
@@ -478,7 +478,7 @@ func resourceACMECertificateUpdate(d *schema.ResourceData, meta interface{}) err
 			dnsProvider.provider = p
 
 			m := v.(map[string]interface{})
-			if z, ok :=  m["zones"]; ok && len(z.(*schema.Set).List()) > 0 {
+			if z, ok := m["zones"]; ok && len(z.(*schema.Set).List()) > 0 {
 				dnsProvider.zones = stringSlice(z.(*schema.Set).List())
 			} else {
 				if zonesRequired == true {
@@ -568,7 +568,7 @@ func resourceACMECertificateHasExpired(d certificateResourceExpander) (bool, err
 
 type DNSProvider struct {
 	provider challenge.Provider
-	zones []string
+	zones    []string
 }
 
 func NewDNSProvider() (*DNSProvider, error) {
@@ -587,11 +587,11 @@ func NewDNSProviderWrapper() (*DNSProviderWrapper, error) {
 	return &DNSProviderWrapper{}, nil
 }
 
-func useProviderForDomain(provider *DNSProvider, domain string) (bool) {
+func useProviderForDomain(provider *DNSProvider, domain string) bool {
 	if len(provider.zones) > 0 {
 		for _, zone := range provider.zones {
-			if strings.HasSuffix(domain, "." + zone) {
-				log.Printf("[DEBUG] useProviderForDomain: zone '%s' matches for domain '%s'", "." + zone, domain)
+			if strings.HasSuffix(domain, "."+zone) {
+				log.Printf("[DEBUG] useProviderForDomain: zone '%s' matches for domain '%s'", "."+zone, domain)
 				return true
 			}
 		}


### PR DESCRIPTION
Multi DNS challenges (validate one multi-domains certificate using multiple DNS challenges/providers) is not usable.

Actually, the ACME provider just calls all "dns_challenge{}" providers for every domains of the certificate. This regularly fails with "Unknown domains" errors from DNS providers modules.

The ACME provider should only call each "dns_challenge{}" provider for domains managed by this type of DNS provider (azure, gandiv5, ...)

Since the ACME provider cannot guess which DNS provider to use for each domain, I propose to add a new optional field named "zones" to do the mapping:

Here is a simple example which works with the proposed changes:
```
resource "tls_private_key" "acme_account" {
    algorithm = "RSA"
}
resource "acme_registration" "reg" {
    account_key_pem = tls_private_key.acme_account.private_key_pem
    email_address   = "xxxx@xxxxx.com"
}
resource "acme_certificate" "multi" {
    account_key_pem           = acme_registration.reg.account_key_pem
    common_name               = "domain.using.azure.example.com"
    subject_alternative_names = [ "domain.using.gandiv5.example.net" ]

    dns_challenge {
        provider = "azure"
        zones = [ "example.com" ]
    }
    dns_challenge {
        provider = "gandiv5"
        zones = [ "example.net" ]
    }
}
```