### PR TITLE
#104 Misguiding documentation Recursive NS

### DIFF
--- a/website/docs/r/certificate.html.markdown
+++ b/website/docs/r/certificate.html.markdown
@@ -240,7 +240,7 @@ machine running Terraform may not have visibility into these public DNS
 records.
 
 To override this default behavior, supply the `recursive_nameservers` to use as
-a list in `host:port` form within the `dns_challenge` block:
+a list in `host:port`:
 
 ```hcl
 resource "acme_certificate" "certificate" {


### PR DESCRIPTION
As per #104 , the documentation is probably wrong as the terraform throws an error when trying to provide the `recursive_nameservers` parameter in the `dns_challenge` block.