### PR TITLE
[docs] Route53: use AWS_SESSION_TOKEN (common)

### DIFF
--- a/website/docs/r/certificate.html.markdown
+++ b/website/docs/r/certificate.html.markdown
@@ -196,6 +196,7 @@ resource "acme_certificate" "certificate" {
       AWS_ACCESS_KEY_ID     = "${var.aws_access_key}"
       AWS_SECRET_ACCESS_KEY = "${var.aws_secret_key}"
       AWS_SESSION_TOKEN     = "${var.aws_security_token}"
+      AWS_DEFAULT_REGION    = "us-east-1"  # OPTIONAL
     }
   }
 

--- a/website/docs/r/certificate.html.markdown
+++ b/website/docs/r/certificate.html.markdown
@@ -195,7 +195,7 @@ resource "acme_certificate" "certificate" {
     config = {
       AWS_ACCESS_KEY_ID     = "${var.aws_access_key}"
       AWS_SECRET_ACCESS_KEY = "${var.aws_secret_key}"
-      AWS_DEFAULT_REGION    = "us-east-1"
+      AWS_SESSION_TOKEN     = "${var.aws_security_token}"
     }
   }
 


### PR DESCRIPTION
AWS nowadays frequently uses session token - and it took me a considerable time to figure out why I was getting this error:

```
error encountered while presenting token for DNS challenge: route53: InvalidClientTokenId: The security token included in the request is invalid.
```