### PR TITLE
introduced (dns challenge) disable_propagation param

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -107,6 +107,11 @@ func resourceACMECertificateV5() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"disable_propagation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"must_staple": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -192,6 +197,12 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 
 	if d.Get("disable_complete_propagation").(bool) {
 		opts = append(opts, dns01.DisableCompletePropagationRequirement())
+	}
+
+	if d.Get("disable_propagation").(bool) {
+		opts = append(opts, dns01.WrapPreCheck(func(domain, fqdn, value string, check dns01.PreCheckFunc) (bool, error) {
+			return true, nil
+		}))
 	}
 
 	if preCheckDelay := d.Get("pre_check_delay").(int); preCheckDelay > 0 {

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -128,6 +128,12 @@ new resource when changed.
   `key_type`, and optionally `subject_alternative_names`) need to be specified.
 * `dns_challenge` (Required) - The [DNS challenges](#using-dns-challenges) to
   use in fulfilling the request.
+* `disable_propagation` (Optional) - Disable the check for propagation 
+  of the TXT challenge record before proceeding with validation.
+  Defaults to `false`. Useful in conjunction with `exec` DNS provider,
+  where the external executable blocks until DNS challenge record was fully
+  propagated. Overrides all other propagation check configuration parameters
+  (`disable_complete_propagation`, `pre_check_delay`, etc).
 * `recursive_nameservers` (Optional) - The [recursive
   nameservers](#manually-specifying-recursive-nameservers-for-propagation-checks)
   that will be used to check for propagation of the challenge record. Defaults

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -132,7 +132,7 @@ new resource when changed.
   of the TXT challenge record before proceeding with validation.
   Defaults to `false`. Useful in conjunction with `exec` DNS provider,
   where the external executable blocks until DNS challenge record was fully
-  propagated. Overrides all other propagation check configuration parameters
+  propagated. Incompatible with other propagation check configuration parameters
   (`disable_complete_propagation`, `pre_check_delay`, etc).
 * `recursive_nameservers` (Optional) - The [recursive
   nameservers](#manually-specifying-recursive-nameservers-for-propagation-checks)


### PR DESCRIPTION
Adds new `disable_propagation` param to disable check for propagation of the challenge DNS record. 

This is meant to work in conjunction with `exec` DNS Challenge Provider, when the external program both updates DNS server configuration and waits for the propagation of the challenge record. 

Useful when running terraform in restricted environments without direct access to the Internet.