### PR TITLE
r/certificate: HTTP and TLS challenges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Verify Modules
         run: go mod verify
       - name: Run Tests
-        run: make tools pebble-start test
+        run: make tools pebble-start memcached-start test
 
   goreleaser:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,4 +48,4 @@ jobs:
       - name: Verify Modules
         run: go mod verify
       - name: Run Tests
-        run: make tools pebble-start test
+        run: make tools pebble-start memcached-start test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -28,6 +28,17 @@ pebble-start: pebble-stop
 pebble-stop:
 	build-support/scripts/pebble-stop.sh
 
+.PHONY: memcached-start
+memcached-start: memcached-stop
+	build-support/scripts/memcached-start.sh
+
+.PHONY: memcached-stop
+memcached-stop:
+	build-support/scripts/memcached-stop.sh
+
+.PHONY: stop-services
+stop-services: memcached-stop pebble-stop
+
 .PHONY: template-generate
 template-generate:
 	@echo "==> Re-generating templates..."

--- a/acme/certificate_challenges.go
+++ b/acme/certificate_challenges.go
@@ -1,0 +1,208 @@
+package acme
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v4/challenge/dns01"
+	"github.com/go-acme/lego/v4/challenge/http01"
+	"github.com/go-acme/lego/v4/challenge/tlsalpn01"
+	"github.com/go-acme/lego/v4/lego"
+	"github.com/go-acme/lego/v4/providers/http/memcached"
+	"github.com/go-acme/lego/v4/providers/http/webroot"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func setCertificateChallengeProviders(client *lego.Client, d *schema.ResourceData) error {
+	// DNS
+	if providers, ok := d.GetOk("dns_challenge"); ok {
+		dnsProvider, err := NewDNSProviderWrapper()
+		if err != nil {
+			return err
+		}
+
+		for _, providerRaw := range providers.([]interface{}) {
+			if p, err := expandDNSChallenge(providerRaw.(map[string]interface{})); err == nil {
+				dnsProvider.providers = append(dnsProvider.providers, p)
+			} else {
+				return err
+			}
+		}
+
+		if err := client.Challenge.SetDNS01Provider(dnsProvider, expandDNSChallengeOptions(d)...); err != nil {
+			return err
+		}
+	}
+
+	// HTTP (server)
+	if provider, ok := d.GetOk("http_challenge"); ok {
+		opts := provider.([]interface{})[0].(map[string]interface{})
+		httpServerProvider := http01.NewProviderServer("", strconv.Itoa(opts["port"].(int)))
+		if proxyHeader, ok := opts["proxy_header"]; ok {
+			httpServerProvider.SetProxyHeader(proxyHeader.(string))
+		}
+
+		if err := client.Challenge.SetHTTP01Provider(httpServerProvider); err != nil {
+			return err
+		}
+	}
+
+	// HTTP (webroot)
+	if provider, ok := d.GetOk("http_webroot_challenge"); ok {
+		httpWebrootProvider, err := webroot.NewHTTPProvider(
+			provider.([]interface{})[0].(map[string]interface{})["directory"].(string))
+
+		if err != nil {
+			return err
+		}
+
+		if err := client.Challenge.SetHTTP01Provider(httpWebrootProvider); err != nil {
+			return err
+		}
+	}
+
+	// HTTP (memcached)
+	if provider, ok := d.GetOk("http_memcached_challenge"); ok {
+		httpMemcachedProvider, err := memcached.NewMemcachedProvider(
+			stringSlice(provider.([]interface{})[0].(map[string]interface{})["hosts"].(*schema.Set).List()))
+
+		if err != nil {
+			return err
+		}
+
+		if err := client.Challenge.SetHTTP01Provider(httpMemcachedProvider); err != nil {
+			return err
+		}
+	}
+
+	// TLS
+	if provider, ok := d.GetOk("tls_challenge"); ok {
+		tlsProvider := tlsalpn01.NewProviderServer(
+			"", strconv.Itoa(provider.([]interface{})[0].(map[string]interface{})["port"].(int)))
+
+		if err := client.Challenge.SetTLSALPN01Provider(tlsProvider); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func expandDNSChallenge(m map[string]interface{}) (challenge.Provider, error) {
+	var providerName string
+
+	if v, ok := m["provider"]; ok && v.(string) != "" {
+		providerName = v.(string)
+	} else {
+		return nil, fmt.Errorf("DNS challenge provider not defined")
+	}
+	// Config only needs to be set if it's defined, otherwise existing env/SDK
+	// defaults are fine.
+	if v, ok := m["config"]; ok {
+		for k, v := range v.(map[string]interface{}) {
+			os.Setenv(k, v.(string))
+		}
+	}
+
+	providerFunc, ok := dnsProviderFactory[providerName]
+	if !ok {
+		return nil, fmt.Errorf("%s: unsupported DNS challenge provider", providerName)
+	}
+
+	return providerFunc()
+}
+
+func expandDNSChallengeOptions(d *schema.ResourceData) []dns01.ChallengeOption {
+	var opts []dns01.ChallengeOption
+	if nameservers := d.Get("recursive_nameservers").([]interface{}); len(nameservers) > 0 {
+		var s []string
+		for _, ns := range nameservers {
+			s = append(s, ns.(string))
+		}
+
+		opts = append(opts, dns01.AddRecursiveNameservers(s))
+	}
+
+	if d.Get("disable_complete_propagation").(bool) {
+		opts = append(opts, dns01.DisableCompletePropagationRequirement())
+	}
+
+	if preCheckDelay := d.Get("pre_check_delay").(int); preCheckDelay > 0 {
+		opts = append(opts, dns01.WrapPreCheck(resourceACMECertificatePreCheckDelay(preCheckDelay)))
+	}
+
+	return opts
+}
+
+// DNSProviderWrapper is a multi-provider wrapper to support multiple
+// DNS challenges.
+type DNSProviderWrapper struct {
+	providers []challenge.Provider
+}
+
+// NewDNSProviderWrapper returns an freshly initialized
+// DNSProviderWrapper.
+func NewDNSProviderWrapper() (*DNSProviderWrapper, error) {
+	return &DNSProviderWrapper{}, nil
+}
+
+// Present implements challenge.Provider for DNSProviderWrapper.
+func (d *DNSProviderWrapper) Present(domain, token, keyAuth string) error {
+	var err error
+	for _, p := range d.providers {
+		err = p.Present(domain, token, keyAuth)
+		if err != nil {
+			err = multierror.Append(err, fmt.Errorf("error encountered while presenting token for DNS challenge: %s", err.Error()))
+		}
+	}
+
+	return err
+}
+
+// CleanUp implements challenge.Provider for DNSProviderWrapper.
+func (d *DNSProviderWrapper) CleanUp(domain, token, keyAuth string) error {
+	var err error
+	for _, p := range d.providers {
+		err = p.CleanUp(domain, token, keyAuth)
+		if err != nil {
+			err = multierror.Append(err, fmt.Errorf("error encountered while cleaning token for DNS challenge: %s", err.Error()))
+		}
+	}
+
+	return err
+}
+
+// Timeout implements challenge.ProviderTimeout for
+// DNSProviderWrapper.
+//
+// The highest polling interval and timeout values defined across all
+// providers is used.
+func (d *DNSProviderWrapper) Timeout() (time.Duration, time.Duration) {
+	var timeout, interval time.Duration
+	for _, p := range d.providers {
+		if pt, ok := p.(challenge.ProviderTimeout); ok {
+			t, i := pt.Timeout()
+			if t > timeout {
+				timeout = t
+			}
+
+			if i > interval {
+				interval = i
+			}
+		}
+	}
+
+	if timeout < 1 {
+		timeout = dns01.DefaultPropagationTimeout
+	}
+
+	if interval < 1 {
+		interval = dns01.DefaultPollingInterval
+	}
+
+	return timeout, interval
+}

--- a/acme/provider_test.go
+++ b/acme/provider_test.go
@@ -41,6 +41,9 @@ const mainIntermediateURL = "https://localhost:15000/intermediates/0"
 // URL to the alternate certificate for preferred chain tests
 const alternateIntermediateURL = "https://localhost:15000/intermediates/1"
 
+// Host:port for memcached
+const memcacheHost = "localhost:11211"
+
 // getPebbleCertificate gets the certificate at the supplied URL.
 func getPebbleCertificate(url string) *x509.Certificate {
 	client := &http.Client{

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -1,6 +1,7 @@
 package acme
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
@@ -9,6 +10,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
+	"os"
 	"reflect"
 	"regexp"
 	"testing"
@@ -16,6 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/rainycape/memcache"
 	"software.sslmate.com/src/go-pkcs12"
 )
 
@@ -245,6 +249,90 @@ func TestAccACMECertificate_preferredChain(t *testing.T) {
 	})
 }
 
+func TestAccACMECertificate_http(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:         testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigHTTP(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "test-http", "test-http2"),
+					testAccCheckACMECertificateIntermediateEqual("acme_certificate.certificate", getPebbleCertificate(mainIntermediateURL)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccACMECertificate_httpWebroot(t *testing.T) {
+	closeServer, serverDir, err := testAccCheckACMECertificateWebrootTestServer()
+	if err != nil {
+		panic(fmt.Errorf("TestAccACMECertificate_httpWebroot: %s", err))
+	}
+
+	defer closeServer()
+	resource.Test(t, resource.TestCase{
+		Providers:         testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigHTTPWebroot(serverDir),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "test-webroot", "test-webroot2"),
+					testAccCheckACMECertificateIntermediateEqual("acme_certificate.certificate", getPebbleCertificate(mainIntermediateURL)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccACMECertificate_httpMemcache(t *testing.T) {
+	closeServer, err := testAccCheckACMECertificateMemcacheTestServer()
+	if err != nil {
+		panic(fmt.Errorf("TestAccACMECertificate_httpMemcache: %s", err))
+	}
+
+	defer closeServer()
+	resource.Test(t, resource.TestCase{
+		Providers:         testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigHTTPMemcache(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "test-webroot", "test-webroot2"),
+					testAccCheckACMECertificateIntermediateEqual("acme_certificate.certificate", getPebbleCertificate(mainIntermediateURL)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccACMECertificate_tls(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:         testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigTLS(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "test-tls", "test-tls2"),
+					testAccCheckACMECertificateIntermediateEqual("acme_certificate.certificate", getPebbleCertificate(mainIntermediateURL)),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckACMECertificateValid(n, cn, san string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -400,6 +488,58 @@ func testAccCheckACMECertificateIntermediateEqual(name string, expected *x509.Ce
 
 		return nil
 	}
+}
+
+func testAccCheckACMECertificateWebrootTestServer() (func(), string, error) {
+	dir, err := os.MkdirTemp(os.TempDir(), "terraform-provider-acme-test-webroot")
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Would use httptest here, but this ensures we don't have to mess with the
+	// default listener that would normally be crated by httptest to ensure it
+	// goes to the correct place, since we need to set this to 5002.
+	server := &http.Server{
+		Addr:    ":5002",
+		Handler: http.FileServer(http.Dir(dir)),
+	}
+	go server.ListenAndServe()
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		server.Shutdown(ctx)
+		os.RemoveAll(dir)
+	}, dir, nil
+}
+
+func testAccCheckACMECertificateMemcacheTestServer() (func(), error) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/acme-challenge/", func(w http.ResponseWriter, r *http.Request) {
+		client, err := memcache.New(memcacheHost)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("memcached connect: %s", err), http.StatusBadRequest)
+			return
+		}
+
+		item, err := client.Get(r.URL.Path)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("memcached get: %s", err), http.StatusBadRequest)
+			return
+		}
+
+		w.Write(item.Value)
+	})
+
+	server := &http.Server{
+		Addr:    ":5002",
+		Handler: mux,
+	}
+	go server.ListenAndServe()
+	return func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		server.Shutdown(ctx)
+	}, nil
 }
 
 func testAccACMECertificateConfig() string {
@@ -789,5 +929,159 @@ resource "acme_certificate" "certificate" {
 		pebbleChallTestDNSSrv,
 		getPebbleCertificateIssuer(alternateIntermediateURL),
 		pebbleChallTestDNSScriptPath,
+	)
+}
+
+func testAccACMECertificateConfigHTTP() string {
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+variable "email_address" {
+  default = "nobody@%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "test-http.${var.domain}"
+  subject_alternative_names = ["test-http2.${var.domain}"]
+
+  http_challenge {
+    port = 5002
+  }
+}
+`, pebbleDirBasic,
+		pebbleCertDomain,
+		pebbleCertDomain,
+	)
+}
+
+func testAccACMECertificateConfigHTTPWebroot(dir string) string {
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+variable "email_address" {
+  default = "nobody@%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "test-webroot.${var.domain}"
+  subject_alternative_names = ["test-webroot2.${var.domain}"]
+
+  http_webroot_challenge {
+    directory = "%s"
+  }
+}
+`, pebbleDirBasic,
+		pebbleCertDomain,
+		pebbleCertDomain,
+		dir,
+	)
+}
+
+func testAccACMECertificateConfigHTTPMemcache() string {
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+variable "email_address" {
+  default = "nobody@%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "test-webroot.${var.domain}"
+  subject_alternative_names = ["test-webroot2.${var.domain}"]
+
+  http_memcached_challenge {
+    hosts = ["%s"]
+  }
+}
+`, pebbleDirBasic,
+		pebbleCertDomain,
+		pebbleCertDomain,
+		memcacheHost,
+	)
+}
+
+func testAccACMECertificateConfigTLS() string {
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+variable "email_address" {
+  default = "nobody@%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+}
+
+resource "acme_registration" "reg" {
+  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "test-tls.${var.domain}"
+  subject_alternative_names = ["test-tls2.${var.domain}"]
+
+  tls_challenge {
+    port = 5001
+  }
+}
+`, pebbleDirBasic,
+		pebbleCertDomain,
+		pebbleCertDomain,
 	)
 }

--- a/build-support/scripts/memcached-start.sh
+++ b/build-support/scripts/memcached-start.sh
@@ -10,6 +10,6 @@ case "$(uname)" in
     # Assuming Ubuntu as that's what our CI runs on. YMMV here, might
     # need to expand this into a separate function for distribution
     # detection if need be.
-    apt-get update && apt-get -y install memcached && /etc/init.d/memcached start
+    sudo apt-get update && sudo apt-get -y install memcached && sudo /etc/init.d/memcached start
     ;;
 esac

--- a/build-support/scripts/memcached-start.sh
+++ b/build-support/scripts/memcached-start.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+case "$(uname)" in
+  "Darwin")
+    brew list memcached > /dev/null 2>&1 || brew install memcached
+    brew services run memcached
+    ;;
+
+  *)
+    # Assuming Ubuntu as that's what our CI runs on. YMMV here, might
+    # need to expand this into a separate function for distribution
+    # detection if need be.
+    apt-get update && apt-get -y install memcached && /etc/init.d/memcached start
+    ;;
+esac

--- a/build-support/scripts/memcached-stop.sh
+++ b/build-support/scripts/memcached-stop.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+case "$(uname)" in
+  "Darwin")
+    brew services stop memcached || exit 0
+    ;;
+
+  *)
+    echo "stopping unsupported on this system, please stop manually."
+esac

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -3,10 +3,6 @@
 The `acme_certificate` resource can be used to create and manage an ACME TLS
 certificate.
 
--> **NOTE:** As the usage model of Terraform generally sees it as being run on
-a different server than a certificate would normally be placed on, the
-`acme_certificate` resource only supports DNS challenges.
-
 ## Example
 
 The below example creates both an account and certificate within the same
@@ -126,14 +122,14 @@ new resource when changed.
   from [`tls_cert_request`][tls-cert-request], or one from an external source,
   in PEM format.  Either this, or the in-resource request options (`common_name`,
   `key_type`, and optionally `subject_alternative_names`) need to be specified.
-* `dns_challenge` (Required) - The [DNS challenges](#using-dns-challenges) to
+* `dns_challenge` (Optional) - The [DNS challenges](#using-dns-challenges) to
   use in fulfilling the request.
 * `recursive_nameservers` (Optional) - The [recursive
   nameservers](#manually-specifying-recursive-nameservers-for-propagation-checks)
-  that will be used to check for propagation of the challenge record. Defaults
+  that will be used to check for propagation of DNS challenge records. Defaults
   to your system-configured DNS resolvers.
 * `disable_complete_propagation` (Optional) - Disable the requiement for full
-  propagation of the TXT challenge record before proceeding with validation.
+  propagation of the TXT challenge records before proceeding with validation.
   Defaults to `false`. Only recommended for testing.
 * `pre_check_delay` (Optional) - Insert a delay after _every_ DNS challenge
   record to allow for extra time for DNS propagation before the certificate is
@@ -144,6 +140,22 @@ new resource when changed.
 -> Be careful with `pre_check_delay` since the delay is executed _per-domain_.
 Take your expected delay and divide it by the number of domains you have
 configured (`common_name` + `subject_alternative_names`).
+
+* `http_challenge` (Optional) - Defines an HTTP challenge to use in fulfilling
+  the request.
+* `http_webroot_challenge` (Optional) - Defines an alternate type of HTTP
+  challenge that can be used to place a file at a location that can be served by
+  an out-of-band webserver.
+* `http_memcached_challenge` (Optional) - Defines an alternate type of HTTP
+  challenge that can be used to serve up challenges to a
+  [Memcached](https://memcached.org/) cluster.
+* `tls_challenge` (Optional) - Defines a TLS challenge to use in fulfilling the
+  request.
+
+-> Only one of `http_challenge`, `http_webroot_challenge`, and
+`http_memcached_challenge` can be defined at once. See the section on [Using
+HTTP and TLS challenges](#using-http-and-tls-challenges) for more details on
+using these and `tls_challenge`.
 
 * `must_staple` (Optional) Enables the [OCSP Stapling Required][ocsp-stapling]
   TLS Security Policy extension. Certificates with this extension must include a
@@ -181,14 +193,10 @@ equivalent in the [staging
 environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
 Pretend Pear X1`.
 
-
 ### Using DNS challenges
 
-As the usage model of Terraform generally sees it as being run on a different
-server than a certificate would normally be placed on, the `acme_certificate`
-resource only supports DNS challenges. This method authenticates certificate
-domains by requiring the requester to place a TXT record on the FQDNs in the
-certificate.
+This method authenticates certificate domains by requiring the requester to
+place a TXT record on the FQDNs in the certificate.
 
 The ACME provider responds to DNS challenges automatically by utilizing one of
 the supported DNS challenge providers. Most providers take credentials as
@@ -324,6 +332,154 @@ supported by the corresponding provider's SDK.
 
 Check the documentation of a specific DNS provider for more details on exactly
 what variables are supported.
+
+### Using HTTP and TLS Challenges
+
+-> It's recommended that you use [DNS challenges](#using-dns-challenges)
+whenever possible to generate certificates with `acme_certificate`. Only use the
+HTTP and TLS challenge types if you don't have access to do DNS challenges, and
+can ensure that you can direct traffic for all domains being authorized to the
+machine running Terraform or the locations served by the
+`http_webroot_challenge` or `http_memcached_challenge` types. Additionally,
+these challenge types do not support wildcard domains. See [Let's Encrypt page
+on challenge types](https://letsencrypt.org/docs/challenge-types/) for more
+details. These challenges have requirements that almost always exclude them from
+being used on [Terraform Cloud](https://www.terraform.io/docs/cloud/) unless you
+are using the [Cloud
+Agents](https://www.terraform.io/docs/cloud/agents/index.html) feature.
+
+`acme_certificate` supports HTTP and TLS challenges. The provider accomplishes
+this by running a small HTTP or TLS service to serve records using the HTTP-01
+or TLS-ALPN-01 challenge types. Additionally, two alternate HTTP challenge
+providers exist that allow HTTP challenges to be satisfied by publishing the
+challenge records either to an arbitrary filesystem location or a
+[Memcached](https://memcached.org/) cluster.
+
+#### Network Requirements for Using `http_challenge` and `tls_challenge`
+
+`http_challenge` and `tls_challenge` by default will listen on their respective
+ports (port 80 for HTTP and port 443 for TLS). These ports are _privileged_ and
+will likely not be accessible by the machine running Terraform.
+
+You can work around this by doing the following:
+
+* On Linux, use [`setcap`](https://man7.org/linux/man-pages/man8/setcap.8.html)
+  to grant escalated network privileges to either Terraform (`setcap
+  'cap_net_bind_service=+eip' \`which terraform\``), or the provider (`setcap
+  'cap_net_bind_service=+ep'
+  .terraform/providers/registry.terraform.io/vancluever/acme/VERSION/ARCH/terraform-provider-acme_vVERSION`).
+  Both have drawbacks: granting capabilites to Terraform itself will mean that
+  Terraform core and any provider launched by it will also have the capability,
+  while re-granting to the provider will possibly be necesasry every time the
+  provider is updated or the repository is initialized with `terraform init`.
+* Use proxies to direct traffic to the ports defined with the `port` option in
+  the challenge clauses. If necessary, use the `proxy_header` option of
+  `http_challenge` to set the header to match the host of the current FQDN being
+  solved.
+
+#### `http_challenge`
+
+The `http_challenge` type supports standard HTTP-01 challenges.
+
+```
+resource "acme_certificate" "certificate" {
+  #...
+
+  http_challenge {
+    port         = "5002"
+    proxy_header = "Forwarded"
+  }
+
+  #...
+}
+```
+
+The options are as follows:
+
+* `port` (Optional) - The port that the challenge server listens on. Default: `80`.
+* `proxy_header` (Optional) - The proxy header to match against. Default:
+  `Host`.
+
+The `proxy_header` option behaves differently depending on its definition:
+
+* When set to `Host`, standard host header validation is used.
+* When set to `Forwarded`, the server looks in the `Forwarded` header for a
+  section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
+  resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
+  for more details.
+* When set to an arbitrary header (example: `X-Forwarded-Host`), that heaader is
+  checked for the host entry in the same way the host header would normally be
+  checked.
+
+#### `http_webroot_challenge`
+
+Use `http_webroot_challenge` to publish a record to a location on the file
+system. The record is published to `DIRECTORY/.well-known/acme-challenge/`. The
+resource will request an HTTP-01 challenge for which an out-of-band process must
+use this data to answer.
+
+```
+resource "acme_certificate" "certificate" {
+  #...
+
+  http_webroot_challenge {
+    directory = "/a/webserver/path"
+  }
+
+  #...
+}
+```
+
+The options are as follows:
+
+* `directory` (Optional) - The directory to publish the record to.
+
+#### `http_memcached_challenge`
+
+Use `http_memcached_challenge` to publish challenge records to a
+[Memcached](https://memcached.org/) cluster. The record is published to
+`/.well-known/acme-challenge/KEY`. The resource will request an HTTP-01
+challenge for which an out-of-band process must use this data to answer.
+
+See the [README.md on
+lego](https://github.com/go-acme/lego/blob/4bb8bea031eb805f361c04ca222f266b9e7feced/providers/http/memcached/README.md)
+for an example using nginx.
+
+```
+resource "acme_certificate" "certificate" {
+  #...
+
+  http_memcached_challenge {
+    hosts = ["127.0.0.1:11211"]
+  }
+
+  #...
+}
+```
+
+The options are as follows:
+
+* `hosts` (Optional) - The hosts to publish the record to.
+
+#### `tls_challenge`
+
+The `tls_challenge` type supports TLS-ALPN-01 challenges.
+
+```
+resource "acme_certificate" "certificate" {
+  #...
+
+  tls_challenge {
+    port = "5001"
+  }
+
+  #...
+}
+```
+
+The options are as follows:
+
+* `port` (Optional) - The port that the challenge server listens on. Default: `443`.
 
 ## Certificate renewal
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -370,7 +370,7 @@ You can work around this by doing the following:
 
 * On Linux, use [`setcap`](https://man7.org/linux/man-pages/man8/setcap.8.html)
   to grant escalated network privileges to either Terraform (`setcap
-  'cap_net_bind_service=+eip' \`which terraform\``), or the provider (`setcap
+  'cap_net_bind_service=+eip' "$(which terraform)"`), or the provider (`setcap
   'cap_net_bind_service=+ep'
   .terraform/providers/registry.terraform.io/vancluever/acme/VERSION/ARCH/terraform-provider-acme_vVERSION`).
   Both have drawbacks: granting capabilites to Terraform itself will mean that

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -344,10 +344,10 @@ what variables are supported.
 whenever possible to generate certificates with `acme_certificate`. Only use the
 HTTP and TLS challenge types if you don't have access to do DNS challenges, and
 can ensure that you can direct traffic for all domains being authorized to the
-machine running Terraform or the locations served by the
-`http_webroot_challenge` or `http_memcached_challenge` types. Additionally,
-these challenge types do not support wildcard domains. See [Let's Encrypt page
-on challenge types](https://letsencrypt.org/docs/challenge-types/) for more
+machine running Terraform, or the locations served by the
+`http_webroot_challenge` and `http_memcached_challenge` types. Additionally,
+these challenge types do not support wildcard domains. See the [Let's Encrypt
+page on challenge types](https://letsencrypt.org/docs/challenge-types/) for more
 details. These challenges have requirements that almost always exclude them from
 being used on [Terraform Cloud](https://www.terraform.io/docs/cloud/) unless you
 are using the [Cloud
@@ -375,8 +375,8 @@ You can work around this by doing the following:
   .terraform/providers/registry.terraform.io/vancluever/acme/VERSION/ARCH/terraform-provider-acme_vVERSION`).
   Both have drawbacks: granting capabilites to Terraform itself will mean that
   Terraform core and any provider launched by it will also have the capability,
-  while re-granting to the provider will possibly be necesasry every time the
-  provider is updated or the repository is initialized with `terraform init`.
+  while capabilities granted to the provider will be lost every time the
+  provider is updated, or the repository is initialized with `terraform init`.
 * Use proxies to direct traffic to the ports defined with the `port` option in
   the challenge clauses. If necessary, use the `proxy_header` option of
   `http_challenge` to set the header to match the host of the current FQDN being
@@ -412,7 +412,7 @@ The `proxy_header` option behaves differently depending on its definition:
   section matching `host=DOMAIN` where `DOMAIN` is the domain currently being
   resolved by the challenge. See [RFC 7239](https://tools.ietf.org/html/rfc7239)
   for more details.
-* When set to an arbitrary header (example: `X-Forwarded-Host`), that heaader is
+* When set to an arbitrary header (example: `X-Forwarded-Host`), that header is
   checked for the host entry in the same way the host header would normally be
   checked.
 
@@ -448,7 +448,7 @@ challenge for which an out-of-band process must use this data to answer.
 
 See the [README.md on
 lego](https://github.com/go-acme/lego/blob/4bb8bea031eb805f361c04ca222f266b9e7feced/providers/http/memcached/README.md)
-for an example using nginx.
+for an example using Nginx.
 
 ```
 resource "acme_certificate" "certificate" {

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -104,24 +104,28 @@ resource "acme_certificate" "certificate" {
 
 The resource takes the following arguments:
 
-~> All arguments in `acme_certificate`, other than `min_days_remaining`, force a
-new resource when changed.
+~> At least one challenge type (`dns_challenge`, `http_challenge`,
+`http_webroot_challenge`, `http_memcached_challenge`, or `tls_challenge`) must
+be specified. It's recommended you use `dns_challenge` whenever possible).
 
 * `account_key_pem` (Required) - The private key of the account that is
-  requesting the certificate.
+  requesting the certificate. Forces a new resource when changed.
 * `common_name` - The certificate's common name, the primary domain that the
-  certificate will be recognized for. Required when not specifying a CSR.
+  certificate will be recognized for. Required when not specifying a CSR. Forces
+  a new resource when changed.
 * `subject_alternative_names` - The certificate's subject alternative names,
   domains that this certificate will also be recognized for. Only valid when not
-  specifying a CSR.
+  specifying a CSR. Forces a new resource when changed.
 * `key_type` - The key type for the certificate's private key. Can be one of:
   `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
   `8192` (for RSA keys of respective length). Required when not specifying a
-  CSR. The default is `2048` (RSA key of 2048 bits).
+  CSR. The default is `2048` (RSA key of 2048 bits). Forces a new resource when
+  changed.
 * `certificate_request_pem` - A pre-created certificate request, such as one
   from [`tls_cert_request`][tls-cert-request], or one from an external source,
-  in PEM format.  Either this, or the in-resource request options (`common_name`,
-  `key_type`, and optionally `subject_alternative_names`) need to be specified.
+  in PEM format.  Either this, or the in-resource request options
+  (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
+  to be specified. Forces a new resource when changed.
 * `dns_challenge` (Optional) - The [DNS challenges](#using-dns-challenges) to
   use in fulfilling the request.
 * `recursive_nameservers` (Optional) - The [recursive
@@ -161,7 +165,8 @@ using these and `tls_challenge`.
   TLS Security Policy extension. Certificates with this extension must include a
   valid OCSP Staple in the TLS handshake for the connection to succeed.
   Defaults to `false`. Note that this option has no effect when using an
-  external CSR - it must be enabled in the CSR itself.
+  external CSR - it must be enabled in the CSR itself. Forces a new resource
+  when changed.
 
 [ocsp-stapling]: https://letsencrypt.org/docs/integration-guide/#implement-ocsp-stapling
 
@@ -181,7 +186,7 @@ provider can be configured correctly.
 * `preferred_chain` - (Optional) The common name of the root of a preferred
   alternate certificate chain offered by the CA. The certificates in
   `issuer_pem` will reflect the chain requested, if available, otherwise the
-  default chain will be provided.
+  default chain will be provided. Forces a new resource when changed.
 
 -> `preferred_chain` can be used to request alternate chains on Let's Encrypt
 during the transition away from their old cross-signed intermediates. See [this
@@ -432,7 +437,7 @@ resource "acme_certificate" "certificate" {
 
 The options are as follows:
 
-* `directory` (Optional) - The directory to publish the record to.
+* `directory` (Required) - The directory to publish the record to.
 
 #### `http_memcached_challenge`
 
@@ -459,7 +464,7 @@ resource "acme_certificate" "certificate" {
 
 The options are as follows:
 
-* `hosts` (Optional) - The hosts to publish the record to.
+* `hosts` (Required) - The hosts to publish the record to.
 
 #### `tls_challenge`
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -104,7 +104,7 @@ resource "acme_certificate" "certificate" {
 
 The resource takes the following arguments:
 
-~> At least one challenge type (`dns_challenge`, `http_challenge`,
+-> At least one challenge type (`dns_challenge`, `http_challenge`,
 `http_webroot_challenge`, `http_memcached_challenge`, or `tls_challenge`) must
 be specified. It's recommended you use `dns_challenge` whenever possible).
 
@@ -381,6 +381,10 @@ You can work around this by doing the following:
   the challenge clauses. If necessary, use the `proxy_header` option of
   `http_challenge` to set the header to match the host of the current FQDN being
   solved.
+
+~> Never run Terraform (or the plugin) as root! If you cannot satisfy the
+networking requirements for `http_challenge` or `tls_challenge`, consider using
+the other challenge types or use [DNS challenges](#using-dns-challenges).
 
 #### `http_challenge`
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
 	github.com/mitchellh/copystructure v1.1.1
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2
 	github.com/zclconf/go-cty v1.7.1 // indirect
 	golang.org/x/tools v0.0.0-20201028111035-eafbe7b904eb // indirect
 	google.golang.org/api v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,6 @@ github.com/hashicorp/terraform-json v0.8.0 h1:XObQ3PgqU52YLQKEaJ08QtUshAfN3yu4u8
 github.com/hashicorp/terraform-json v0.8.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
 github.com/hashicorp/terraform-plugin-go v0.2.1 h1:EW/R8bB2Zbkjmugzsy1d27yS8/0454b3MtYHkzOknqA=
 github.com/hashicorp/terraform-plugin-go v0.2.1/go.mod h1:10V6F3taeDWVAoLlkmArKttR3IULlRWFAGtQIQTIDr4=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4 h1:6k0WcxFgVqF/GUFHPvAH8FIrCkoA1RInXzSxhkKamPg=
-github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4/go.mod h1:z+cMZ0iswzZOahBJ3XmNWgWkVnAd2bl8g+FhyyuPDH4=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0 h1:4EHNOAjwiYCeBxY16rt2KwyRNNVsCaVO3kWBbiXfYM0=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0/go.mod h1:z+cMZ0iswzZOahBJ3XmNWgWkVnAd2bl8g+FhyyuPDH4=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -560,6 +558,7 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2 h1:dq90+d51/hQRaHEqRAsQ1rE/pC1GUS4sc2rCbbFsAIY=
 github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2/go.mod h1:7tZKcyumwBO6qip7RNQ5r77yrssm9bfCowcLEBcU5IA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
This adds providers for HTTP and TLS challenges, supporting all types currently supported by lego:

* HTTP-01: `http_challenge` represents the in-tool webserver that will answer HTTP challenges. This usually requires escalated privileges to bind the privileged ports, or proxy server access. `http_webroot_challenge` and `http_memcached_challenge` provide alternate challenge types that can potentially work around the networking requirements.
* TLS-ALPN-01: `tls_challenge` represents the in-tool webserver.

We still recommend that you use DNS challenges whenever possible. The addition of the challenges here helps fill a niche that some of our practitioners have where access to DNS is not possible or it is just simpler to use HTTP (possibly single-server deployments, easy access to webroot content locations, working around propagation issues, etc). This also streamlines the features and removes the maintenance burden for those who are maintaining a fork to add these capabilities (like @saitho generously had!)
