### PR TITLE
Pass the preferred chain attribute when creating a CSR

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -257,6 +257,7 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 		cert, err = client.Certificate.ObtainForCSR(certificate.ObtainForCSRRequest{
 			CSR:    csr,
 			Bundle: true,
+			PreferredChain: d.Get("preferred_chain").(string),
 		})
 	} else {
 		cn := d.Get("common_name").(string)

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -71,7 +71,7 @@ func TestAccACMECertificate_CSR_PreferredChain(t *testing.T) {
 		ExternalProviders: testAccExternalProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccACMECertificateCSRConfigWithPerferredChain(),
+				Config: testAccACMECertificateCSRConfigWithPreferredChain(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
 					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
@@ -717,7 +717,7 @@ resource "acme_certificate" "certificate" {
 	)
 }
 
-func testAccACMECertificateCSRConfigWithPerferredChain() string {
+func testAccACMECertificateCSRConfigWithPreferredChain() string {
 	return fmt.Sprintf(`
 provider "acme" {
   server_url = "%s"


### PR DESCRIPTION
When creating a CSR also pass the perferred_chain attribute so that you
can control what chain you get. As of writing CSR issuing is broken on
the staging CA because the 'default' chain has expired, and it's not
possible to select an alternate chain.