### PR TITLE
fix(azuredns): add environment variables mapping

### DIFF
--- a/acme/dnsplugin/dns_provider_factory.go
+++ b/acme/dnsplugin/dns_provider_factory.go
@@ -200,6 +200,13 @@ var dnsProviderFactory = map[string]dnsProviderFactoryFunc{
 		return p, nil
 	},
 	"azuredns": func() (challenge.Provider, error) {
+		mapEnvironmentVariableValues(map[string]string{
+			"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
+			"ARM_CLIENT_SECRET":   "AZURE_CLIENT_SECRET",
+			"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
+			"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
+			"ARM_TENANT_ID":       "AZURE_TENANT_ID",
+		})
 		p, err := azuredns.NewDNSProvider()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Hello @vancluever,

There is a missing configuration of environment variables in order to keep the same interface between `azuredns` and `azure` providers.

Thanks !