### PR TITLE
r/certificate: add control for post-auth cert timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ website/vendor
 terraform-provider-acme
 
 .direnv/
+
+coverage.out

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -203,6 +203,11 @@ func resourceACMECertificateV5() *schema.Resource {
 				Default:  "",
 				ForceNew: true,
 			},
+			"cert_timeout": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+			},
 			"certificate_url": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -208,6 +208,13 @@ Pretend Pear X1`.
 * `revoke_certificate_on_destroy` - Enables revocation of a certificate upon destroy,
 which includes when a resource is re-created. Default is `true`.
 
+* `cert_timeout` - Controls the timeout in seconds for certificate requests
+  that are made after challenges are complete. Defaults to 30 seconds.
+
+-> As mentioned, `cert_timeout` does nothing until all challenges are complete.
+If you are looking to control timeouts related to a particular challenge (such
+as a DNS challenge), see that challenge provider's specific options.
+
 ### Using DNS challenges
 
 This method authenticates certificate domains by requiring the requester to


### PR DESCRIPTION
This adds a timeout for the post-certificate request process.

Note that this *only* affects requests after authorization and is the same as setting `--cert.timeout=TIMEOUT` in lego. Timeout for specific DNS providers should still be controlled via their individual provider options.