### PR TITLE
fix(azuredns): remove environment variables replication

### DIFF
--- a/acme/dnsplugin/dns_provider_factory.go
+++ b/acme/dnsplugin/dns_provider_factory.go
@@ -200,13 +200,6 @@ var dnsProviderFactory = map[string]dnsProviderFactoryFunc{
 		return p, nil
 	},
 	"azuredns": func() (challenge.Provider, error) {
-		mapEnvironmentVariableValues(map[string]string{
-			"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
-			"ARM_CLIENT_SECRET":   "AZURE_CLIENT_SECRET",
-			"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
-			"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
-			"ARM_TENANT_ID":       "AZURE_TENANT_ID",
-		})
 		p, err := azuredns.NewDNSProvider()
 		if err != nil {
 			return nil, err

--- a/build-support/generate-dns-providers/main.go
+++ b/build-support/generate-dns-providers/main.go
@@ -24,13 +24,6 @@ var envVarAliases = map[string]map[string]string{
 		"ARM_TENANT_ID":       "AZURE_TENANT_ID",
 		"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
 	},
-	"azuredns": {
-		"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
-		"ARM_CLIENT_SECRET":   "AZURE_CLIENT_SECRET",
-		"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
-		"ARM_TENANT_ID":       "AZURE_TENANT_ID",
-		"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
-	},
 }
 
 // providerURLs is a list of providers to override provider pages


### PR DESCRIPTION
Hello @vancluever,

After all you were right.

I have tested the replication of environment variables but it is no longer usable because of the [`DefaultAzureCredentials` behavior](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash) that is used inside `azuredns` provider.
In fact when setting `AZURE_CLIENT_ID` it automatically trying to use MSI authentication and bypasses other authentication means (like azure CLI).

Therefore the ability to seperate configuration variables between `terraform-provider-azurerm` provider that is using `ARM_`prefixed variables and `terraform-provider-acme/azuredns` provider by using only `AZURE_` prefixed variables is mandatory to correctly configure expected behavior.

Thanks for your understanding.