### PR TITLE
Add option to acme_certificate to set revocation reason

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -249,6 +249,10 @@ func resourceACMECertificateV5() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"revoke_certificate_reason": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -466,11 +470,13 @@ func resourceACMECertificateDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	if remaining >= 0 {
-		if err := client.Certificate.Revoke(cert.Certificate); err != nil {
-			return err
+		maybeReason, ok := d.GetOk("revoke_certificate_reason")
+		if ok {
+			reason := uint(maybeReason.(int))
+			return client.Certificate.RevokeWithReason(cert.Certificate, &reason)
 		}
+		return client.Certificate.Revoke(cert.Certificate)
 	}
-
 	return nil
 }
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -208,6 +208,10 @@ Pretend Pear X1`.
 * `revoke_certificate_on_destroy` - Enables revocation of a certificate upon destroy,
 which includes when a resource is re-created. Default is `true`.
 
+* `revoke_certificate_reason` - If `revoke_certificate_on_destroy` is `true`, use
+this reason code as a number (from [RFC 5280, section 5.3.1](https://www.rfc-editor.org/rfc/rfc5280#section-5.3.1).
+By default, no reason provided. Some CA's require a reason to be provided.
+
 * `cert_timeout` - Controls the timeout in seconds for certificate requests
   that are made after challenges are complete. Defaults to 30 seconds.
 


### PR DESCRIPTION
Some CA's don't accept the null revocation reason (or some other reasons, like `0 unspecified`) and reject the revocation, failing the `terraform apply` run.

This PR adds a fully backward-compatible way of providing a reason code for certificate revocation.
