### PR TITLE
r/registration: fix "inconsistent result after apply" errors

### DIFF
--- a/acme/resource_acme_registration.go
+++ b/acme/resource_acme_registration.go
@@ -86,9 +86,14 @@ func resourceACMERegistrationCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	d.SetId(reg.URI)
+	_, user, err := expandACMEClient(d, meta, true)
+	if err != nil {
+		return err
+	}
 
-	return resourceACMERegistrationRead(d, meta)
+	// save the reg
+	d.SetId(reg.URI)
+	return saveACMERegistration(d, user.Registration)
 }
 
 func resourceACMERegistrationRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This fixes an issue where, when destroying a registration and re-creating it by doing something like renaming the resources, "inconsistent result after apply" errors may occur.

This was actually a red herring in the fact that it's actually masking other errors that happen during resource creation, such as the fact that a registration with the private key exists, but was deactivated (something that seemingly does not show up during actual creation of an account at Let's Encrypt, I guess).

The fix here should allow these kinds of errors to properly show up.

Fixes #374.