### PR TITLE
fix: terraform cloud oidc envs

### DIFF
--- a/acme/dnsplugin/dns_provider_factory.go
+++ b/acme/dnsplugin/dns_provider_factory.go
@@ -190,9 +190,11 @@ var dnsProviderFactory = map[string]dnsProviderFactoryFunc{
 		mapEnvironmentVariableValues(map[string]string{
 			"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
 			"ARM_CLIENT_SECRET":   "AZURE_CLIENT_SECRET",
+			"ARM_OIDC_TOKEN":      "AZURE_OIDC_TOKEN",
 			"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
 			"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
 			"ARM_TENANT_ID":       "AZURE_TENANT_ID",
+			"ARM_USE_OIDC":        "AZURE_USE_OIDC",
 		})
 		p, err := azure.NewDNSProvider()
 		if err != nil {
@@ -205,9 +207,11 @@ var dnsProviderFactory = map[string]dnsProviderFactoryFunc{
 		mapEnvironmentVariableValues(map[string]string{
 			"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
 			"ARM_CLIENT_SECRET":   "AZURE_CLIENT_SECRET",
+			"ARM_OIDC_TOKEN":      "AZURE_OIDC_TOKEN",
 			"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
 			"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
 			"ARM_TENANT_ID":       "AZURE_TENANT_ID",
+			"ARM_USE_OIDC":        "AZURE_USE_OIDC",
 		})
 		p, err := azuredns.NewDNSProvider()
 		if err != nil {

--- a/build-support/generate-dns-providers/main.go
+++ b/build-support/generate-dns-providers/main.go
@@ -23,6 +23,8 @@ var envVarAliases = map[string]map[string]string{
 		"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
 		"ARM_TENANT_ID":       "AZURE_TENANT_ID",
 		"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
+		"ARM_OIDC_TOKEN":      "AZURE_OIDC_TOKEN",
+		"ARM_USE_OIDC":        "AZURE_USE_OIDC",
 	},
 	"azuredns": {
 		"ARM_CLIENT_ID":       "AZURE_CLIENT_ID",
@@ -30,6 +32,8 @@ var envVarAliases = map[string]map[string]string{
 		"ARM_SUBSCRIPTION_ID": "AZURE_SUBSCRIPTION_ID",
 		"ARM_TENANT_ID":       "AZURE_TENANT_ID",
 		"ARM_RESOURCE_GROUP":  "AZURE_RESOURCE_GROUP",
+		"ARM_OIDC_TOKEN":      "AZURE_OIDC_TOKEN",
+		"ARM_USE_OIDC":        "AZURE_USE_OIDC",
 	},
 }
 

--- a/docs/guides/dns-providers-azure.md
+++ b/docs/guides/dns-providers-azure.md
@@ -69,8 +69,10 @@ configuration values:
 
 * `ARM_CLIENT_ID` - alias for `AZURE_CLIENT_ID`.
 * `ARM_CLIENT_SECRET` - alias for `AZURE_CLIENT_SECRET`.
+* `ARM_OIDC_TOKEN` - alias for `AZURE_OIDC_TOKEN`.
 * `ARM_RESOURCE_GROUP` - alias for `AZURE_RESOURCE_GROUP`.
 * `ARM_SUBSCRIPTION_ID` - alias for `AZURE_SUBSCRIPTION_ID`.
 * `ARM_TENANT_ID` - alias for `AZURE_TENANT_ID`.
+* `ARM_USE_OIDC` - alias for `AZURE_USE_OIDC`.
 
 

--- a/docs/guides/dns-providers-azuredns.md
+++ b/docs/guides/dns-providers-azuredns.md
@@ -70,9 +70,11 @@ configuration values:
 
 * `ARM_CLIENT_ID` - alias for `AZURE_CLIENT_ID`.
 * `ARM_CLIENT_SECRET` - alias for `AZURE_CLIENT_SECRET`.
+* `ARM_OIDC_TOKEN` - alias for `AZURE_OIDC_TOKEN`.
 * `ARM_RESOURCE_GROUP` - alias for `AZURE_RESOURCE_GROUP`.
 * `ARM_SUBSCRIPTION_ID` - alias for `AZURE_SUBSCRIPTION_ID`.
 * `ARM_TENANT_ID` - alias for `AZURE_TENANT_ID`.
+* `ARM_USE_OIDC` - alias for `AZURE_USE_OIDC`.
 
 ## Description
 


### PR DESCRIPTION
Related to https://github.com/go-acme/lego/issues/2027 and included in v2.20.0 release of terraform-provider-acme

Fix to allow reading the OIDC token from https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_oidc#oidc-token
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#oidc_token

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#use_oidc is optional

Example use case
https://developer.hashicorp.com/terraform/tutorials/cloud/dynamic-credentials#