### PR TITLE
d/server_url: new data source

### DIFF
--- a/acme/data_source_acme_server_url.go
+++ b/acme/data_source_acme_server_url.go
@@ -1,0 +1,24 @@
+package acme
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceACMEServerURL() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceACMEServerURLRead,
+		Schema: map[string]*schema.Schema{
+			"server_url": {
+				Type:        schema.TypeString,
+				Description: "The server URL the provider is configured with.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceACMEServerURLRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(meta.(*Config).ServerURL)
+	d.Set("server_url", meta.(*Config).ServerURL)
+	return nil
+}

--- a/acme/data_source_acme_server_url_test.go
+++ b/acme/data_source_acme_server_url_test.go
@@ -1,0 +1,50 @@
+package acme
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccACMEServerURL_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMEServerURLConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.acme_server_url.url",
+						"id",
+						pebbleDirBasic,
+					),
+					resource.TestCheckResourceAttr(
+						"data.acme_server_url.url",
+						"server_url",
+						pebbleDirBasic,
+					),
+					resource.TestCheckOutput(
+						"server_url",
+						pebbleDirBasic,
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccACMEServerURLConfig() string {
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+data "acme_server_url" "url" {}
+
+output "server_url" {
+  value = data.acme_server_url.url.server_url
+}
+`, pebbleDirBasic)
+}

--- a/acme/provider.go
+++ b/acme/provider.go
@@ -21,6 +21,10 @@ func Provider() *schema.Provider {
 			"acme_certificate":  resourceACMECertificate(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"acme_server_url": dataSourceACMEServerURL(),
+		},
+
 		ConfigureFunc: configureProvider,
 	}
 }

--- a/docs/data-sources/registration.md
+++ b/docs/data-sources/registration.md
@@ -1,0 +1,33 @@
+# acme_server_url
+
+The `acme_server_url` data source can be used to retrieve the CA server URL
+that the provider is currently configured for.
+
+## Example
+
+The following example populates the `server_url` output with the currently
+configured CA server URL.
+
+```hcl
+provider "acme" {
+  server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+}
+
+data "acme_server_url" "url" {}
+
+output "server_url" {
+  value = data.acme_server_url.url.server_url
+}
+```
+
+#### Argument Reference
+
+This data source takes no arguments.
+
+#### Attribute Reference
+
+The following attributes are exported:
+
+* `id`: the CA server URL that the provider is currently configured for. 
+* `server_url`: the CA server URL that the provider is currently configured
+  for. Same as `id`.

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,12 @@
               gopls
               protoc-gen-go
               protoc-gen-go-grpc
+              gotestsum
             ];
+
+            shellHook = ''
+              export PATH="$HOME/go/bin:$PATH"
+            '';
           }
         );
     };


### PR DESCRIPTION
This adds the acme_server_url data source, which gives the current CA server URL that the provider is configured for.

This is a quality-of-life resource designed to make it easier to write modules and configurations that need to depend on the provider's resources downstream.

Fixes #392.