### PR TITLE
r/certificate: Add certificate_serial attribute

### DIFF
--- a/acme/acme_structure_test.go
+++ b/acme/acme_structure_test.go
@@ -280,7 +280,7 @@ func TestACME_certDaysRemaining_CACert(t *testing.T) {
 
 func TestACME_splitPEMBundle_noData(t *testing.T) {
 	b := []byte{}
-	_, _, _, err := splitPEMBundle(b)
+	_, _, _, _, err := splitPEMBundle(b)
 	if err == nil {
 		t.Fatalf("expected error due to no PEM data")
 	}
@@ -288,7 +288,7 @@ func TestACME_splitPEMBundle_noData(t *testing.T) {
 
 func TestACME_splitPEMBundle_CAFirst(t *testing.T) {
 	b := testBadCertBundleText + testBadCertBundleText
-	_, _, _, err := splitPEMBundle([]byte(b))
+	_, _, _, _, err := splitPEMBundle([]byte(b))
 	if err == nil {
 		t.Fatalf("expected error due to CA cert being first")
 	}
@@ -311,7 +311,7 @@ func TestACME_bundleToPKCS12_base64IsPadded(t *testing.T) {
 
 func TestACME_splitPEMBundle_singleCert(t *testing.T) {
 	b := testBadCertBundleText
-	_, _, _, err := splitPEMBundle([]byte(b))
+	_, _, _, _, err := splitPEMBundle([]byte(b))
 	if err == nil {
 		t.Fatalf("expected error due to only one cert being present")
 	}

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -254,6 +254,10 @@ func resourceACMECertificateV5() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"certificate_serial": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"certificate_p12_password": {
 				Type:      schema.TypeString,
 				Optional:  true,

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -611,6 +611,13 @@ func testAccCheckACMECertificateValid(n, cn, san string) resource.TestCheckFunc 
 			return fmt.Errorf("expected certificate_not_after to be %q, got %q", expectedNotAfter, actualNotAfter)
 		}
 
+		// Serial
+		actualSerial := rs.Primary.Attributes["certificate_serial"]
+		expectedSerial := x509Cert.SerialNumber.String()
+		if expectedSerial != actualSerial {
+			return fmt.Errorf("expected certificate_serial to be %q, got %q", expectedSerial, actualSerial)
+		}
+
 		return nil
 	}
 }

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -632,3 +632,5 @@ Refer to that field for the current URL of the certificate.
   argument. This field is empty if creating a certificate from a CSR.
 * `certificate_not_after` - The expiry date of the certificate, laid out in
   RFC3339 format (`2006-01-02T15:04:05Z07:00`).
+* `certificate_serial` - The serial number, in string format, as reported by
+  the CA.


### PR DESCRIPTION
This adds the `certificate_serial` computed attribute to the `acme_certificate` resource. This allows you to get the serial number from the certificate, much like the expiry date that is in the `certificate_not_after` field.