### PR TITLE
r/registration: Allow private key to be managed by resource

### DIFF
--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -853,12 +853,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -900,12 +895,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -949,12 +939,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "reg_private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.reg_private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1008,12 +993,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "reg_private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.reg_private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1069,12 +1049,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1116,12 +1091,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1166,12 +1136,7 @@ variable "password" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1215,12 +1180,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1264,12 +1224,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1311,12 +1266,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1360,12 +1310,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1398,12 +1343,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1437,12 +1377,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1476,12 +1411,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1515,12 +1445,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1554,12 +1479,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = "${tls_private_key.private_key.private_key_pem}"
   email_address   = "${var.email_address}"
 }
 
@@ -1592,12 +1512,7 @@ variable "domain" {
   default = "%s"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = tls_private_key.private_key.private_key_pem
   email_address   = var.email_address
 }
 

--- a/build-support/scripts/pebble-stop.sh
+++ b/build-support/scripts/pebble-stop.sh
@@ -59,7 +59,7 @@ fi
 
 # pebble-challtestsrv
 if [ -n "${PEBBLE_CHALLTESTSRV_PID}" ]; then
-  if [ "$(ps -p "${PEBBLE_CHALLTESTSRV_PID}" -o comm=)" != "pebble-challtestsrv" ]; then
+  if [[ "$(ps -p "${PEBBLE_CHALLTESTSRV_PID}" -o comm=)" =~ ^pebble-challtestsrv.* ]]; then
     echo "error: stale PID file ${PEBBLE_CHALLTESTSRV_PIDFILE}; PID ${PEBBLE_CHALLTESTSRV_PID} not found or not \"pebble-challtestsrv\".">&2
     PEBBLE_CHALLTESTSRV_ERROR="true"
   fi

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,15 +32,12 @@ CAs such as Let's Encrypt.
 
 The following example can be used to create an account using the
 [`acme_registration`][resource-acme-registration] resource, and a certificate
-using the [`acme_certificate`][resource-acme-certificate] resource. The
-initial private key is created using the
-[`tls_private_key`][resource-tls-private-key] resource, but can be supplied via
-other means. DNS validation is performed by using [Amazon Route 53][aws-route-53],
-for which appropriate credentials are assumed to be in your environment.
+using the [`acme_certificate`][resource-acme-certificate] resource. DNS
+validation is performed by using [Amazon Route 53][aws-route-53], for which
+appropriate credentials are assumed to be in your environment.
 
 [resource-acme-registration]: ./resources/registration.md
 [resource-acme-certificate]: ./resources/certificate.md
-[resource-tls-private-key]: https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key
 [aws-route-53]: https://aws.amazon.com/route53/
 
 -> The directory URLs in all examples in this provider reference Let's Encrypt's
@@ -63,12 +60,7 @@ provider "acme" {
   server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = tls_private_key.private_key.private_key_pem
   email_address   = "nobody@example.com"
 }
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -25,12 +25,7 @@ provider "acme" {
   server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
 }
 
-resource "tls_private_key" "private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = tls_private_key.private_key.private_key_pem
   email_address   = "nobody@example.com"
 }
 
@@ -67,12 +62,7 @@ provider "acme" {
   server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
 }
 
-resource "tls_private_key" "reg_private_key" {
-  algorithm = "RSA"
-}
-
 resource "acme_registration" "reg" {
-  account_key_pem = tls_private_key.reg_private_key.private_key_pem
   email_address   = "nobody@example.com"
 }
 

--- a/docs/resources/registration.md
+++ b/docs/resources/registration.md
@@ -22,6 +22,23 @@ provider instances][multiple-provider-instances].
 
 ## Example
 
+### Basic Example
+
+The following is the most basic example, supplying only a contact email address
+to the resource.
+
+```hcl
+provider "acme" {
+  server_url = "https://acme-staging-v02.api.letsencrypt.org/directory"
+}
+
+resource "acme_registration" "reg" {
+  email_address   = "nobody@example.com"
+}
+```
+
+### Using a Pre-Existing Private Key
+
 The following creates an account off of a private key generated with the
 [`tls_private_key`][resource-tls-private-key] resource.
 
@@ -49,7 +66,17 @@ changed.
 
 The resource takes the following arguments:
 
-* `account_key_pem` (Required) - The private key used to identify the account.
+* `account_key_pem` (Optional) - The private key used to identify the account.
+  If not provided, the key will be generated according to the
+  `account_key_algorithm`, `account_key_ecdsa_curve`, and
+  `account_key_rsa_bits` settings.
+* `account_key_algorithm` (Optional) - The algorithm to use for the private key
+  when generating from scratch. Supported settings: `RSA` and `EDCSA`. Default
+  settings: `ECDSA`.
+* `account_key_ecdsa_curve` (Optional) - ECDSA curve to use for ECDSA key
+  types. Supported settings: `P256` and `P384`. Default: `P384`.
+* `account_key_rsa_bits` (Optional) - The key length to use for RSA key types.
+  Supported settings: `2048`, `3072`, and `4096`. Default: `4096`.
 * `email_address` (Required) - The contact email address for the account.
 * `external_account_binding` (Optional) - An external account binding for the
   registration, usually used to link the registration with an account in a
@@ -63,6 +90,8 @@ The resource takes the following arguments:
 The following attributes are exported:
 
 * `id`: The original full URL of the account.
+* `account_key_pem`: The private key used to identify the account (will be
+  generated if not provided).
 * `registration_url`: The current full URL of the account.
 
 -> `id` and `registration_url` will usually be the same and will usually only


### PR DESCRIPTION
This sets the `private_key_pem` attribute in `acme_registration` to Optional/Computed, allowing the resource to manage the key fully (and hence removing the need to have the key supplied by the likes of `tls_private_key`).

The goal here is to facilitate easier resource management when working with EAB attributes - not needing to supply the private key ensures that you can change the EAB binding, have the old registration deactivated, and the new one activated with a new private key. Without that last
part, registration will fail, as the unchanged private key would still be associated with the deactivated registration. If using the `tls_private_key` resource to supply the key, one would need to taint that
resource, and with other (out-of-band) methods, the private key would need to be changed by other means.

Aside from this goal, however, moving the private key to be managed by the resource markedly simplifies resource use in general, as the need to supply an external key is now relegated to edge cases, none of which we have examples for at this time.