### PR TITLE
r/registration: add state migration

### DIFF
--- a/acme/acme_migrations.go
+++ b/acme/acme_migrations.go
@@ -9,6 +9,36 @@ import (
 	"github.com/mitchellh/copystructure"
 )
 
+// resourceACMERegistrationStateUpgraderV1 returns the state upgrader
+// that handles migrations from version 1 to version 2 for
+// acme_registration.
+func resourceACMERegistrationStateUpgraderV1() schema.StateUpgrader {
+	return schema.StateUpgrader{
+		Version: 1,
+		Type:    resourceACMERegistrationV1().CoreConfigSchema().ImpliedType(),
+		Upgrade: resourceACMERegistrationStateUpgraderV1Func,
+	}
+}
+
+// resourceACMERegistrationStateUpgraderV1Func provides Terraform 0.12
+// state upgrade functionality from schema version 1 to schema
+// version 2 for acme_registration.
+func resourceACMERegistrationStateUpgraderV1Func(
+	_ context.Context,
+	rawState map[string]interface{},
+	meta interface{},
+) (map[string]interface{}, error) {
+	z, err := copystructure.Copy(rawState)
+	if err != nil {
+		return nil, err
+	}
+	result := z.(map[string]interface{})
+	result["account_key_algorithm"] = keyAlgorithmECDSA
+	result["account_key_ecdsa_curve"] = keyECDSACurveP384
+	result["account_key_rsa_bits"] = 4096
+	return result, nil
+}
+
 // resourceACMECertificateStateUpgraderV4 returns the state upgrader
 // that handles migrations from version 4 to version 5 for
 // acme_certificate.

--- a/acme/acme_migrations_test.go
+++ b/acme/acme_migrations_test.go
@@ -76,6 +76,39 @@ func testACMECertificateStateData012V5() map[string]interface{} {
 	}
 }
 
+func testACMERegistrationStateData012V1() map[string]interface{} {
+	return map[string]interface{}{
+		"account_key_pem": "key",
+		"email_address":   "hello@localhost",
+		"external_account_binding": []interface{}{
+			map[string]interface{}{
+				"key_id":      "kid",
+				"hmac_base64": "hmac",
+			},
+		},
+		"id":               "id",
+		"registration_url": "regurl",
+	}
+}
+
+func testACMERegistrationStateData012V2() map[string]interface{} {
+	return map[string]interface{}{
+		"account_key_pem":         "key",
+		"account_key_algorithm":   "ECDSA",
+		"account_key_ecdsa_curve": "P384",
+		"account_key_rsa_bits":    4096,
+		"email_address":           "hello@localhost",
+		"external_account_binding": []interface{}{
+			map[string]interface{}{
+				"key_id":      "kid",
+				"hmac_base64": "hmac",
+			},
+		},
+		"id":               "id",
+		"registration_url": "regurl",
+	}
+}
+
 func TestResourceACMECertificateStateUpgraderV3Func(t *testing.T) {
 	expected := testACMECertificateStateData012V4()
 	actual, err := resourceACMECertificateStateUpgraderV3Func(context.TODO(), testACMECertificateStateData012V3(), nil)
@@ -105,5 +138,17 @@ func TestResourceACMECertificateStateUpgraderV4Func(t *testing.T) {
 
 	if id := actual["id"].(string); !uuidRegexp.MatchString(id) {
 		t.Errorf("expected UUID as ID, got %q", id)
+	}
+}
+
+func TestResourceACMERegistrationStateUpgraderV1Func(t *testing.T) {
+	expected := testACMERegistrationStateData012V2()
+	actual, err := resourceACMERegistrationStateUpgraderV1Func(context.TODO(), testACMERegistrationStateData012V1(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if diff := cmp.Diff(expected, actual, nil); diff != "" {
+		t.Errorf("state migration v1 -> v2 mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/acme/resource_acme_registration.go
+++ b/acme/resource_acme_registration.go
@@ -10,15 +10,18 @@ import (
 // resourceACMERegistration returns the current version of the
 // acme_registration resource and needs to be updated when the schema
 // version is incremented.
-func resourceACMERegistration() *schema.Resource { return resourceACMERegistrationV1() }
+func resourceACMERegistration() *schema.Resource { return resourceACMERegistrationV2() }
 
-func resourceACMERegistrationV1() *schema.Resource {
+func resourceACMERegistrationV2() *schema.Resource {
 	return &schema.Resource{
 		Create:        resourceACMERegistrationCreate,
 		Read:          resourceACMERegistrationRead,
 		Delete:        resourceACMERegistrationDelete,
 		MigrateState:  resourceACMERegistrationMigrateState,
-		SchemaVersion: 1,
+		SchemaVersion: 2,
+		StateUpgraders: []schema.StateUpgrader{
+			resourceACMERegistrationStateUpgraderV1(),
+		},
 		Schema: map[string]*schema.Schema{
 			"account_key_pem": {
 				Type:      schema.TypeString,

--- a/acme/resource_acme_registration_legacy_schemas.go
+++ b/acme/resource_acme_registration_legacy_schemas.go
@@ -1,0 +1,95 @@
+package acme
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceACMERegistrationV1() *schema.Resource {
+	return &schema.Resource{
+		Create:        resourceACMERegistrationCreate,
+		Read:          resourceACMERegistrationRead,
+		Delete:        resourceACMERegistrationDelete,
+		MigrateState:  resourceACMERegistrationMigrateState,
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"account_key_pem": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Computed:  true,
+				ForceNew:  true,
+				Sensitive: true,
+				ConflictsWith: []string{
+					"account_key_algorithm",
+					"account_key_ecdsa_curve",
+					"account_key_rsa_bits",
+				},
+			},
+			// https://letsencrypt.org/docs/integration-guide/#supported-key-algorithms
+			// NOTE: Our internal functions support more, but we need to restrict to
+			// what's listed here for Let's Encrypt Specifically. This also applies
+			// to the specific RSA and ECDSA lengths/curves.
+			"account_key_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{keyAlgorithmRSA, keyAlgorithmECDSA},
+					false,
+				),
+				Default:       keyAlgorithmECDSA,
+				ConflictsWith: []string{"account_key_pem"},
+			},
+			"account_key_ecdsa_curve": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{keyECDSACurveP256, keyECDSACurveP384},
+					false,
+				),
+				Default:       keyECDSACurveP384,
+				ConflictsWith: []string{"account_key_pem", "account_key_rsa_bits"},
+			},
+			"account_key_rsa_bits": {
+				Type:          schema.TypeInt,
+				Optional:      true,
+				ForceNew:      true,
+				ValidateFunc:  validation.IntInSlice([]int{2048, 3072, 4096}),
+				Default:       4096,
+				ConflictsWith: []string{"account_key_pem", "account_key_ecdsa_curve"},
+			},
+			"email_address": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"external_account_binding": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key_id": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							ForceNew:  true,
+						},
+						"hmac_base64": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							ForceNew:  true,
+						},
+					},
+				},
+			},
+			"registration_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}


### PR DESCRIPTION
The addition of `account_key_algorithm`, `account_key_ecdsa_curve`, and `account_key_rsa_bits` into the configuration with defaults requires a state migration to ensure that the default values are written to state before the first post-upgrade plan happens on existing configurations. This prevents erroneous re-creation of resources that have their keys defined with `tls_private_key` et al.

Fixes #424.