### PR TITLE
r/cert: use modern PKCS12 encryption

### DIFF
--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -280,7 +280,7 @@ func bundleToPKCS12(bundle, key []byte, password string) ([]byte, error) {
 		return nil, err
 	}
 
-	pfxData, err := pkcs12.Encode(rand.Reader, pk, cb[0], cb[1:], password)
+	pfxData, err := pkcs12.Modern2023.Encode(pk, cb[0], cb[1:], password)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This just updates our call for PKCS encoding to use the Modern2023 encryption settings in go-pkcs12; this should ensure secure encryption and compatibility with modern OpenSSL et al.