### PR TITLE
workflows: remove unnecessary stuff from build image for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,20 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: Delete unneeded software
+        run: |
+          echo "Free disk space before removing:"
+          df -h
+          echo ""
+          echo "Removing dotnet, android, GHC and CodeQL..."
+          echo "  > sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL"
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          echo "Removing all docker images..."
+          echo "  > sudo docker image prune --all --force"
+          sudo docker image prune --all --force
+          echo ""
+          echo "Free disk space after removing:"
+          df -h
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
The release process is somewhat disk-heavy. We download a large number of dependencies and also build for a large amount of targets, and for a while now we've seemed to run up on the VM disk space limit on GHA - or so I thought...

Turns out the GHA image is quite bloated and a bit all over the place. The base install has a number of runtimes that we don't need (Dotnet, Android, GHC and CodeQL), Docker images are installed that we don't use, and the disk layout is odd (a 74GB volume in `/mnt` that I don't really understand what it's for, maybe Docker mounts or just arbitrary scratch space). I'm guessing this is for maybe a common build profile, but is totally unnecessary for what we do.

There's https://github.com/easimon/maximize-build-space which was super helpful in figuring this out, but unfortunately their approach is not just a "set it and forget it" since they still mount the LVM volume they create in the build root (`/home/runner/work/REPO/REPO`), which is actually where not all the fun is happening in our case - it's happening in `/tmp`, `/home/runner/.cache`, `/home/runner/go` and likely elsewhere too. With all of these moving parts, I'm a bit loath at this time to try and figure out where all the settings would need to go to fix this (and/or if they can be cleanly done in their appropriate actions - for example, `actions/setup-go` does not seem to have a setting to set `GOPATH`).

Luckily, doing the software removal part that `easimon/maximize-build-space` does **nearly doubles** the amount of disk space available to us in `/` (38 GB, up from 21 GB!). Given that until recently, release builds failing due to disk space was intermittent - implying that we are just running up on the free space in the base image on the root FS - this should be plenty for hopefully a long time, so I'm just adding this part for now. This got v2.28.0 out the door.

If we end up hitting this limit again, I'll look further into how we can massage the image (likely figuring out how we can make use of the `/mnt` partition, setting `GOPATH`, temporary directories for builds, etc).