### PR TITLE
r/certificate: Allow no common name to be defined

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -58,6 +58,7 @@ func resourceACMECertificateV5() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
+				AtLeastOneOf:  []string{"common_name", "subject_alternative_names", "certificate_request_pem"},
 				ConflictsWith: []string{"certificate_request_pem"},
 			},
 			"subject_alternative_names": {
@@ -66,6 +67,7 @@ func resourceACMECertificateV5() *schema.Resource {
 				Elem:          &schema.Schema{Type: schema.TypeString},
 				Set:           schema.HashString,
 				ForceNew:      true,
+				AtLeastOneOf:  []string{"common_name", "subject_alternative_names", "certificate_request_pem"},
 				ConflictsWith: []string{"certificate_request_pem"},
 			},
 			"key_type": {
@@ -80,6 +82,7 @@ func resourceACMECertificateV5() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
+				AtLeastOneOf:  []string{"common_name", "subject_alternative_names", "certificate_request_pem"},
 				ConflictsWith: []string{"common_name", "subject_alternative_names", "key_type"},
 			},
 			"min_days_remaining": {
@@ -88,9 +91,16 @@ func resourceACMECertificateV5() *schema.Resource {
 				Default:  30,
 			},
 			"dns_challenge": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				AtLeastOneOf: []string{"dns_challenge", "http_challenge", "http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge", "tls_challenge"},
+				Type:     schema.TypeList,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"dns_challenge",
+					"http_challenge",
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+					"tls_challenge",
+				},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"provider": {
@@ -107,11 +117,22 @@ func resourceACMECertificateV5() *schema.Resource {
 				},
 			},
 			"http_challenge": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				AtLeastOneOf:  []string{"dns_challenge", "http_challenge", "http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge", "tls_challenge"},
-				ConflictsWith: []string{"http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge"},
-				MaxItems:      1,
+				Type:     schema.TypeList,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"dns_challenge",
+					"http_challenge",
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+					"tls_challenge",
+				},
+				ConflictsWith: []string{
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+				},
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"port": {
@@ -128,11 +149,22 @@ func resourceACMECertificateV5() *schema.Resource {
 				},
 			},
 			"http_webroot_challenge": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				AtLeastOneOf:  []string{"dns_challenge", "http_challenge", "http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge", "tls_challenge"},
-				ConflictsWith: []string{"http_challenge", "http_memcached_challenge", "http_s3_challenge"},
-				MaxItems:      1,
+				Type:     schema.TypeList,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"dns_challenge",
+					"http_challenge",
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+					"tls_challenge",
+				},
+				ConflictsWith: []string{
+					"http_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+				},
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"directory": {
@@ -143,9 +175,16 @@ func resourceACMECertificateV5() *schema.Resource {
 				},
 			},
 			"http_memcached_challenge": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				AtLeastOneOf:  []string{"dns_challenge", "http_challenge", "http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge", "tls_challenge"},
+				Type:     schema.TypeList,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"dns_challenge",
+					"http_challenge",
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+					"tls_challenge",
+				},
 				ConflictsWith: []string{"http_challenge", "http_webroot_challenge", "http_s3_challenge"},
 				MaxItems:      1,
 				Elem: &schema.Resource{
@@ -161,9 +200,16 @@ func resourceACMECertificateV5() *schema.Resource {
 				},
 			},
 			"http_s3_challenge": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				AtLeastOneOf:  []string{"dns_challenge", "http_challenge", "http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge", "tls_challenge"},
+				Type:     schema.TypeList,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"dns_challenge",
+					"http_challenge",
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+					"tls_challenge",
+				},
 				ConflictsWith: []string{"http_challenge", "http_webroot_challenge", "http_memcached_challenge"},
 				MaxItems:      1,
 				Elem: &schema.Resource{
@@ -176,10 +222,17 @@ func resourceACMECertificateV5() *schema.Resource {
 				},
 			},
 			"tls_challenge": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				AtLeastOneOf: []string{"dns_challenge", "http_challenge", "http_webroot_challenge", "http_memcached_challenge", "http_s3_challenge", "tls_challenge"},
-				MaxItems:     1,
+				Type:     schema.TypeList,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"dns_challenge",
+					"http_challenge",
+					"http_webroot_challenge",
+					"http_memcached_challenge",
+					"http_s3_challenge",
+					"tls_challenge",
+				},
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"port": {
@@ -316,8 +369,12 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 			PreferredChain: d.Get("preferred_chain").(string),
 		})
 	} else {
+		domains := []string{}
 		cn := d.Get("common_name").(string)
-		domains := []string{cn}
+		if cn != "" {
+			domains = append(domains, cn)
+		}
+
 		if s, ok := d.GetOk("subject_alternative_names"); ok {
 			for _, v := range stringSlice(s.(*schema.Set).List()) {
 				if v != cn {

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -101,11 +101,10 @@ be specified. It's recommended you use `dns_challenge` whenever possible).
 * `account_key_pem` (Required) - The private key of the account that is
   requesting the certificate. Forces a new resource when changed.
 * `common_name` - The certificate's common name, the primary domain that the
-  certificate will be recognized for. Required when not specifying a CSR. Forces
-  a new resource when changed.
-* `subject_alternative_names` - The certificate's subject alternative names,
-  domains that this certificate will also be recognized for. Only valid when not
-  specifying a CSR. Forces a new resource when changed.
+  certificate will be recognized for. Forces a new resource when changed.
+* `subject_alternative_names` - The certificate's subject alternative names;
+  domains that this certificate will also be recognized for. Forces a new
+  resource when changed.
 * `key_type` - The key type for the certificate's private key. Can be one of:
   `P256` and `P384` (for ECDSA keys of respective length) or `2048`, `4096`, and
   `8192` (for RSA keys of respective length). Required when not specifying a
@@ -113,9 +112,17 @@ be specified. It's recommended you use `dns_challenge` whenever possible).
   changed.
 * `certificate_request_pem` - A pre-created certificate request, such as one
   from [`tls_cert_request`][tls-cert-request], or one from an external source,
-  in PEM format.  Either this, or the in-resource request options
-  (`common_name`, `key_type`, and optionally `subject_alternative_names`) need
-  to be specified. Forces a new resource when changed.
+  in PEM format. Forces a new resource when changed.
+
+-> One of `common_name`, `subject_alternative_names`, or
+`certificate_request_pem` must be specified. `certificate_request_pem`
+conflicts with `common_name` and `subject_alternative_names`; You cannot have
+`certificate_request_pem` defined at the same time as `common_name` or
+`subject_alternative_names`, and vice versa. Finally, `common_name` can be
+blank while `subject_alternative_names` is defined, and vice versa; in this
+case with the `classic` Let's Encrypt profile, the first domain defined in
+`subject_alternative_names` becomes the common name.
+
 * `dns_challenge` (Optional) - The [DNS challenges](#using-dns-challenges) to
   use in fulfilling the request.
 * `recursive_nameservers` (Optional) - The recursive nameservers that will be


### PR DESCRIPTION
This is in prep for addressing #485, but it's also been the case for some time that a common name has not only not been required, but not recommended even. This allows you to just skip the common name.