### PR TITLE
r/certificate: Add profile support

### DIFF
--- a/acme/provider_test.go
+++ b/acme/provider_test.go
@@ -45,6 +45,9 @@ const pebbleDirBasic = "https://localhost:14000/dir"
 // URL for the EAB pebble directory
 const pebbleDirEAB = "https://localhost:14001/dir"
 
+// URL for the static-profile pebble directory
+const pebbleDirProfile = "https://localhost:14002/dir"
+
 // Address for the challenge/test recursive nameserver
 const pebbleChallTestDNSSrv = "localhost:5553"
 
@@ -56,6 +59,9 @@ const mainIntermediateURL = "https://localhost:15000/intermediates/0"
 
 // URL to the alternate certificate for preferred chain tests
 const alternateIntermediateURL = "https://localhost:15000/intermediates/1"
+
+// URL to the main certificate for static-profile tests
+const profileIntermediateURL = "https://localhost:15002/intermediates/0"
 
 // URL to cert status (non-EAB)
 const certStatusURL = "https://localhost:15000/cert-status-by-serial/"

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -272,6 +272,12 @@ func resourceACMECertificateV5() *schema.Resource {
 				Default:  "",
 				ForceNew: true,
 			},
+			"profile": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+				ForceNew: true,
+			},
 			"cert_timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -367,6 +373,7 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 			CSR:            csr,
 			Bundle:         true,
 			PreferredChain: d.Get("preferred_chain").(string),
+			Profile:        d.Get("profile").(string),
 		})
 	} else {
 		domains := []string{}
@@ -388,6 +395,7 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 			Bundle:         true,
 			MustStaple:     d.Get("must_staple").(bool),
 			PreferredChain: d.Get("preferred_chain").(string),
+			Profile:        d.Get("profile").(string),
 		})
 	}
 

--- a/build-support/pebblecfg/alt-profile.json
+++ b/build-support/pebblecfg/alt-profile.json
@@ -1,0 +1,18 @@
+{
+  "pebble": {
+    "listenAddress": "0.0.0.0:14002",
+    "managementListenAddress": "0.0.0.0:15002",
+    "certificate": "test/certs/localhost/cert.pem",
+    "privateKey": "test/certs/localhost/key.pem",
+    "httpPort": 7002,
+    "tlsPort": 7001,
+    "ocspResponderURL": "",
+    "externalAccountBindingRequired": false,
+    "profiles": {
+      "tfacmetest": {
+        "description": "Mock TF ACME test profile",
+        "validityPeriod": 576000
+      }
+    }
+  }
+}

--- a/build-support/pebblecfg/basic.json
+++ b/build-support/pebblecfg/basic.json
@@ -7,6 +7,13 @@
     "httpPort": 5002,
     "tlsPort": 5001,
     "ocspResponderURL": "",
-    "externalAccountBindingRequired": false
+    "externalAccountBindingRequired": false,
+    "profiles": {
+      "classic": {
+        "description": "Emulates the Let's Encrypt classic (default) profile",
+        "promoteCommonName": true,
+        "validityPeriod": 7776000
+      }
+    }
   }
 }

--- a/build-support/scripts/pebble-start.sh
+++ b/build-support/scripts/pebble-start.sh
@@ -3,7 +3,7 @@
 set -e
 
 GOPATH="$(go env GOPATH)"
-PEBBLE_VERSION="2.3.1"
+PEBBLE_VERSION="2.8.0-vancluever3"
 # config files are relative to script dir
 PEBBLE_CFGFILE="../pebblecfg/basic.json"
 PEBBLE_PIDFILE="/tmp/pebble.pid"
@@ -12,16 +12,21 @@ PEBBLE_LOGFILE="/tmp/pebble.log"
 PEBBLE_EAB_CFGFILE="../pebblecfg/eab.json"
 PEBBLE_EAB_PIDFILE="/tmp/pebble-eab.pid"
 PEBBLE_EAB_LOGFILE="/tmp/pebble-eab.log"
+# config files are relative to script dir
+PEBBLE_PROFILE_CFGFILE="../pebblecfg/alt-profile.json"
+PEBBLE_PROFILE_PIDFILE="/tmp/pebble-profile.pid"
+PEBBLE_PROFILE_LOGFILE="/tmp/pebble-profile.log"
 PEBBLE_CHALLTESTSRV_PIDFILE="/tmp/pebble-challtestsrv.pid"
 PEBBLE_CHALLTESTSRV_LOGFILE="/tmp/pebble-challtestsrv.log"
 PEBBLE_CHALLTESTSRV_DNS_SERVER="0.0.0.0:5553"
-PEBBLE_SRC="https://github.com/letsencrypt/pebble.git"
+PEBBLE_SRC="https://github.com/vancluever/pebble.git"
 PEBBLE_DIR="src/github.com/letsencrypt/pebble"
 PEBBLE_CA_CERT="test/certs/pebble.minica.pem"
 
 # Calculate path names
 BASIC_CFG="$(realpath "$(dirname "$0")"/${PEBBLE_CFGFILE})"
 EAB_CFG="$(realpath "$(dirname "$0")"/${PEBBLE_EAB_CFGFILE})"
+PROFILE_CFG="$(realpath "$(dirname "$0")"/${PEBBLE_PROFILE_CFGFILE})"
 
 # Enable alternate roots
 export PEBBLE_ALTERNATE_ROOTS="1"
@@ -63,6 +68,9 @@ echo -n $! > "${PEBBLE_PIDFILE}"
 # EAB pebble instance
 pebble -dnsserver "${PEBBLE_CHALLTESTSRV_DNS_SERVER}" -config "${EAB_CFG}" > "${PEBBLE_EAB_LOGFILE}" 2>&1 &
 echo -n $! > "${PEBBLE_EAB_PIDFILE}"
+# alt profile pebble instance
+pebble -dnsserver "${PEBBLE_CHALLTESTSRV_DNS_SERVER}" -config "${PROFILE_CFG}" > "${PEBBLE_PROFILE_LOGFILE}" 2>&1 &
+echo -n $! > "${PEBBLE_PROFILE_PIDFILE}"
 cat << EOS
 
 pebble instances (and pebble-challtestsrv) started.
@@ -71,12 +79,15 @@ pebble PID:              ${PEBBLE_PIDFILE} (PID $(cat ${PEBBLE_PIDFILE}))
 pebble Log:              ${PEBBLE_LOGFILE}
 pebble PID (EAB):        ${PEBBLE_EAB_PIDFILE} (PID $(cat ${PEBBLE_EAB_PIDFILE}))
 pebble Log (EAB):        ${PEBBLE_EAB_LOGFILE}
+pebble PID (Profile):    ${PEBBLE_PROFILE_PIDFILE} (PID $(cat ${PEBBLE_PROFILE_PIDFILE}))
+pebble Log (Profile):    ${PEBBLE_PROFILE_LOGFILE}
 pebble-challtestsrv PID: ${PEBBLE_CHALLTESTSRV_PIDFILE} (PID $(cat ${PEBBLE_CHALLTESTSRV_PIDFILE}))
 pebble-challtestsrv Log: ${PEBBLE_CHALLTESTSRV_LOGFILE}
 Configured DNS server:   ${PEBBLE_CHALLTESTSRV_DNS_SERVER}
 Repository directory:    ${GOPATH}/${PEBBLE_DIR}
 Config file:             ${BASIC_CFG}
 Config file (EAB):       ${EAB_CFG}
+Config file (Profile):   ${PROFILE_CFG}
 Root CA certificate:     ${GOPATH}/${PEBBLE_DIR}/${PEBBLE_CA_CERT}
 
 EOS

--- a/build-support/scripts/pebble-stop.sh
+++ b/build-support/scripts/pebble-stop.sh
@@ -2,6 +2,7 @@
 
 PEBBLE_PIDFILE="/tmp/pebble.pid"
 PEBBLE_EAB_PIDFILE="/tmp/pebble-eab.pid"
+PEBBLE_PROFILE_PIDFILE="/tmp/pebble-profile.pid"
 PEBBLE_CHALLTESTSRV_PIDFILE="/tmp/pebble-challtestsrv.pid"
 
 PEBBLE_ERROR="false"
@@ -18,12 +19,17 @@ if [ -f "${PEBBLE_EAB_PIDFILE}" ]; then
   PEBBLE_EAB_PID="$(cat "${PEBBLE_EAB_PIDFILE}")"
 fi
 
+PEBBLE_PROFILE_PID=""
+if [ -f "${PEBBLE_PROFILE_PIDFILE}" ]; then
+  PEBBLE_PROFILE_PID="$(cat "${PEBBLE_PROFILE_PIDFILE}")"
+fi
+
 PEBBLE_CHALLTESTSRV_PID=""
 if [ -f "${PEBBLE_CHALLTESTSRV_PIDFILE}" ]; then
   PEBBLE_CHALLTESTSRV_PID="$(cat "${PEBBLE_CHALLTESTSRV_PIDFILE}")"
 fi
 
-if [ -z "${PEBBLE_PID}" ] && [ -z "${PEBBLE_EAB_PID}" ] && [ -z "${PEBBLE_CHALLTESTSRV_PID}" ]; then
+if [ -z "${PEBBLE_PID}" ] && [ -z "${PEBBLE_EAB_PID}" ] && [ -z "${PEBBLE_PROFILE_PID}" ] && [ -z "${PEBBLE_CHALLTESTSRV_PID}" ]; then
   echo "no pebble instances nor pebble-challtestsrv are running; do not need to stop.">&2
   exit 0
 fi
@@ -54,6 +60,21 @@ if [ -n "${PEBBLE_EAB_PID}" ]; then
     kill "${PEBBLE_EAB_PID}" && \
       echo "pebble (PID ${PEBBLE_EAB_PID}) stopped." && \
       rm "${PEBBLE_EAB_PIDFILE}"
+  fi
+fi
+
+# pebble (Profile)
+
+if [ -n "${PEBBLE_PROFILE_PID}" ]; then
+  if [ "$(ps -p "${PEBBLE_PROFILE_PID}" -o comm=)" != "pebble" ]; then
+    echo "error: stale PID file ${PEBBLE_PROFILE_PIDFILE}; PID ${PEBBLE_PROFILE_PID} not found or is not \"pebble\".">&2
+    PEBBLE_PROFILE_ERROR="true"
+  fi
+
+  if [ "${PEBBLE_PROFILE_ERROR}"  != "true" ]; then
+    kill "${PEBBLE_PROFILE_PID}" && \
+      echo "pebble (PID ${PEBBLE_PROFILE_PID}) stopped." && \
+      rm "${PEBBLE_PROFILE_PIDFILE}"
   fi
 fi
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -202,6 +202,14 @@ equivalent in the [staging
 environment](https://letsencrypt.org/docs/staging-environment/) is `(STAGING)
 Pretend Pear X1`.
 
+* `profile` - (Optional) The ACME profile to use when requesting the
+  certificate. This can be used to control generation parameters according to
+  the specific CA. The default is blank (no profile); forces a new resource
+  when changed.
+
+-> Let's Encrypt publishes details on their profiles at
+<https://letsencrypt.org/docs/profiles/>.
+
 * `revoke_certificate_on_destroy` - Enables revocation of a certificate upon destroy,
 which includes when a resource is re-created. Default is `true`.
 


### PR DESCRIPTION
This adds the `profile` attribute to `acme_certificate`, allowing you to control the profile used to generate the certificate at the CA.

For example, at Let's Encrypt, this can be used to request a cert without a common name and shorter authorization validity times (`tlsserver`), or one with a shorter lifetime (`shortlived`).

The default is to not request a profile (this is the "classic" profile at Let's Encrypt).

Fixes #485.