### PR TITLE
r/certificate: Mark certificate_not_after as unknown on renewal

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -483,6 +483,7 @@ func resourceACMECertificateCustomizeDiff(_ context.Context, d *schema.ResourceD
 		d.SetNewComputed("certificate_not_after")
 		d.SetNewComputed("private_key_pem")
 		d.SetNewComputed("issuer_pem")
+		d.SetNewComputed("certificate_serial")
 	}
 
 	return nil

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -480,6 +480,7 @@ func resourceACMECertificateCustomizeDiff(_ context.Context, d *schema.ResourceD
 		d.SetNewComputed("certificate_p12")
 		d.SetNewComputed("certificate_url")
 		d.SetNewComputed("certificate_domain")
+		d.SetNewComputed("certificate_not_after")
 		d.SetNewComputed("private_key_pem")
 		d.SetNewComputed("issuer_pem")
 	}


### PR DESCRIPTION
When the provider renews a certificate, it doesn't mark `certificate_not_after` as newly computed value, so it doesn't show up as a change in the plan. And if this attribute is used as an input to another resource, it will cause the apply to fail as the value changes midway through the apply:

```
│ Error: Provider produced inconsistent final plan
│
│ When expanding the plan for kubernetes_deployment.service to include
│ new values learned so far during apply, provider
│ "registry.opentofu.org/hashicorp/kubernetes" produced an invalid new
│ value for .spec[0].template[0].spec[0].container[0].env[1].value:
│ was cty.StringVal("2025-07-08T00:56:38Z"), but now
│  cty.StringVal("2025-09-30T04:43:31Z").
│
│ This is a bug in the provider, which should be reported in the
│ provider's own issue tracker.
```

Of course Terraform thinks it's an issue with the provider of the consuming resource, but here it's the `acme_certificate` resource that caused the change in value.