### PR TITLE
Apply some modernizations and linter stuff

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+version: "2"
+linters:
+  disable:
+    - errcheck

--- a/acme/acme_migrations.go
+++ b/acme/acme_migrations.go
@@ -25,14 +25,14 @@ func resourceACMERegistrationStateUpgraderV1() schema.StateUpgrader {
 // version 2 for acme_registration.
 func resourceACMERegistrationStateUpgraderV1Func(
 	_ context.Context,
-	rawState map[string]interface{},
-	meta interface{},
-) (map[string]interface{}, error) {
+	rawState map[string]any,
+	meta any,
+) (map[string]any, error) {
 	z, err := copystructure.Copy(rawState)
 	if err != nil {
 		return nil, err
 	}
-	result := z.(map[string]interface{})
+	result := z.(map[string]any)
 	result["account_key_algorithm"] = keyAlgorithmECDSA
 	result["account_key_ecdsa_curve"] = keyECDSACurveP384
 	result["account_key_rsa_bits"] = 4096
@@ -55,9 +55,9 @@ func resourceACMECertificateStateUpgraderV4() schema.StateUpgrader {
 // version 5 for acme_certificate.
 func resourceACMECertificateStateUpgraderV4Func(
 	_ context.Context,
-	rawState map[string]interface{},
-	meta interface{},
-) (map[string]interface{}, error) {
+	rawState map[string]any,
+	meta any,
+) (map[string]any, error) {
 	resourceUUID, err := uuid.GenerateUUID()
 	if err != nil {
 		return nil, fmt.Errorf("error generating new UUID for resource: %s", err)
@@ -67,7 +67,7 @@ func resourceACMECertificateStateUpgraderV4Func(
 	if err != nil {
 		return nil, err
 	}
-	result := z.(map[string]interface{})
+	result := z.(map[string]any)
 	result["id"] = resourceUUID
 	return result, nil
 }
@@ -88,25 +88,25 @@ func resourceACMECertificateStateUpgraderV3() schema.StateUpgrader {
 // version 4 for acme_certificate.
 func resourceACMECertificateStateUpgraderV3Func(
 	_ context.Context,
-	rawState map[string]interface{},
-	meta interface{},
-) (map[string]interface{}, error) {
+	rawState map[string]any,
+	meta any,
+) (map[string]any, error) {
 	z, err := copystructure.Copy(rawState)
 	if err != nil {
 		return nil, err
 	}
-	result := z.(map[string]interface{})
+	result := z.(map[string]any)
 
 	a, ok := rawState["dns_challenge"]
 	if ok {
-		b, ok := a.([]interface{})
+		b, ok := a.([]any)
 		if ok && len(b) > 0 {
-			c, ok := b[0].(map[string]interface{})
+			c, ok := b[0].(map[string]any)
 			if ok {
 				d, ok := c["recursive_nameservers"]
 				if ok {
 					// Should be safe here to access this key directly.
-					delete(result["dns_challenge"].([]interface{})[0].(map[string]interface{}), "recursive_nameservers")
+					delete(result["dns_challenge"].([]any)[0].(map[string]any), "recursive_nameservers")
 					result["recursive_nameservers"] = d
 				}
 			}

--- a/acme/acme_migrations_011.go
+++ b/acme/acme_migrations_011.go
@@ -10,7 +10,7 @@ import (
 // resourceACMERegistrationMigrateState is the outer migration function for
 // acme_registration, dispatching to specific incremental version upgraders as
 // need be.
-func resourceACMERegistrationMigrateState(version int, os *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceACMERegistrationMigrateState(version int, os *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	// Guard against a nil state.
 	if os == nil {
 		return nil, nil
@@ -21,7 +21,7 @@ func resourceACMERegistrationMigrateState(version int, os *terraform.InstanceSta
 		return os, nil
 	}
 
-	var migrateFunc func(*terraform.InstanceState, interface{}) error
+	var migrateFunc func(*terraform.InstanceState, any) error
 	switch version {
 	case 0:
 		log.Printf("[DEBUG] Migrating acme_registration state: old v%d state: %#v", version, os)
@@ -41,7 +41,7 @@ func resourceACMERegistrationMigrateState(version int, os *terraform.InstanceSta
 
 // migrateACMERegistrationStateV1 handles migration of acme_registration from
 // schema version 0 to version 1.
-func migrateACMERegistrationStateV1(is *terraform.InstanceState, meta interface{}) error {
+func migrateACMERegistrationStateV1(is *terraform.InstanceState, meta any) error {
 	delete(is.Attributes, "server_url")
 	delete(is.Attributes, "registration_body")
 	delete(is.Attributes, "registration_new_authz_url")
@@ -53,7 +53,7 @@ func migrateACMERegistrationStateV1(is *terraform.InstanceState, meta interface{
 // resourceACMECertificateMigrateState is the outer migration function for
 // acme_certificate, dispatching to specific incremental version upgraders as
 // need be.
-func resourceACMECertificateMigrateState(version int, os *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceACMECertificateMigrateState(version int, os *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	// Guard against a nil state.
 	if os == nil {
 		return nil, nil
@@ -64,7 +64,7 @@ func resourceACMECertificateMigrateState(version int, os *terraform.InstanceStat
 		return os, nil
 	}
 
-	var migrateFunc func(*terraform.InstanceState, interface{}) error
+	var migrateFunc func(*terraform.InstanceState, any) error
 	switch version {
 	case 3:
 		log.Printf("[DEBUG] Migrating acme_certificate state: old v%d state: %#v", version, os)
@@ -93,7 +93,7 @@ func resourceACMECertificateMigrateState(version int, os *terraform.InstanceStat
 
 // migrateACMECertificateStateV4 handles migration of
 // acme_certificate from schema version 3 to version 4.
-func migrateACMECertificateStateV4(is *terraform.InstanceState, meta interface{}) error {
+func migrateACMECertificateStateV4(is *terraform.InstanceState, meta any) error {
 	// There has ever only been one "dns_challenge" key allowed in
 	// state, so we should be safe to just iterate over every key and
 	// look for the set hash, and re-write that back to zero.
@@ -122,7 +122,7 @@ func migrateACMECertificateStateV4(is *terraform.InstanceState, meta interface{}
 
 // migrateACMECertificateStateV1 handles migration of
 // acme_certificate from schema version 2 to version 3.
-func migrateACMECertificateStateV3(is *terraform.InstanceState, meta interface{}) error {
+func migrateACMECertificateStateV3(is *terraform.InstanceState, meta any) error {
 	// There has ever only been one "dns_challenge" key allowed in
 	// state, so we should be safe to just iterate over every key and
 	// look for the set hash, and re-write that back to zero.
@@ -154,7 +154,7 @@ func migrateACMECertificateStateV3(is *terraform.InstanceState, meta interface{}
 
 // migrateACMECertificateStateV1 handles migration of acme_certificate from
 // schema version 1 to version 2.
-func migrateACMECertificateStateV2(is *terraform.InstanceState, meta interface{}) error {
+func migrateACMECertificateStateV2(is *terraform.InstanceState, meta any) error {
 	delete(is.Attributes, "account_ref")
 
 	return nil
@@ -162,7 +162,7 @@ func migrateACMECertificateStateV2(is *terraform.InstanceState, meta interface{}
 
 // migrateACMECertificateStateV1 handles migration of acme_certificate from
 // schema version 0 to version 1.
-func migrateACMECertificateStateV1(is *terraform.InstanceState, meta interface{}) error {
+func migrateACMECertificateStateV1(is *terraform.InstanceState, meta any) error {
 	delete(is.Attributes, "server_url")
 	delete(is.Attributes, "http_challenge_port")
 	delete(is.Attributes, "tls_challenge_port")

--- a/acme/acme_migrations_test.go
+++ b/acme/acme_migrations_test.go
@@ -10,18 +10,18 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
-func testACMECertificateStateData012V3() map[string]interface{} {
-	return map[string]interface{}{
+func testACMECertificateStateData012V3() map[string]any {
+	return map[string]any{
 		"account_key_pem":           "key",
 		"common_name":               "foobar",
-		"subject_alternative_names": []interface{}{"barbar", "bazbar"},
+		"subject_alternative_names": []any{"barbar", "bazbar"},
 		"key_type":                  "2048",
 		"certificate_request_pem":   "req",
 		"min_days_remaining":        "30",
-		"dns_challenge": []interface{}{
-			map[string]interface{}{
+		"dns_challenge": []any{
+			map[string]any{
 				"provider":              "route53",
-				"recursive_nameservers": []interface{}{"my.name.server"},
+				"recursive_nameservers": []any{"my.name.server"},
 			},
 		},
 		"must_staple":        "0",
@@ -32,20 +32,20 @@ func testACMECertificateStateData012V3() map[string]interface{} {
 	}
 }
 
-func testACMECertificateStateData012V4() map[string]interface{} {
-	return map[string]interface{}{
+func testACMECertificateStateData012V4() map[string]any {
+	return map[string]any{
 		"account_key_pem":           "key",
 		"common_name":               "foobar",
-		"subject_alternative_names": []interface{}{"barbar", "bazbar"},
+		"subject_alternative_names": []any{"barbar", "bazbar"},
 		"key_type":                  "2048",
 		"certificate_request_pem":   "req",
 		"min_days_remaining":        "30",
-		"dns_challenge": []interface{}{
-			map[string]interface{}{
+		"dns_challenge": []any{
+			map[string]any{
 				"provider": "route53",
 			},
 		},
-		"recursive_nameservers": []interface{}{"my.name.server"},
+		"recursive_nameservers": []any{"my.name.server"},
 		"must_staple":           "0",
 		"certificate_domain":    "foobar",
 		"private_key_pem":       "certkey",
@@ -54,20 +54,20 @@ func testACMECertificateStateData012V4() map[string]interface{} {
 	}
 }
 
-func testACMECertificateStateData012V5() map[string]interface{} {
-	return map[string]interface{}{
+func testACMECertificateStateData012V5() map[string]any {
+	return map[string]any{
 		"account_key_pem":           "key",
 		"common_name":               "foobar",
-		"subject_alternative_names": []interface{}{"barbar", "bazbar"},
+		"subject_alternative_names": []any{"barbar", "bazbar"},
 		"key_type":                  "2048",
 		"certificate_request_pem":   "req",
 		"min_days_remaining":        "30",
-		"dns_challenge": []interface{}{
-			map[string]interface{}{
+		"dns_challenge": []any{
+			map[string]any{
 				"provider": "route53",
 			},
 		},
-		"recursive_nameservers": []interface{}{"my.name.server"},
+		"recursive_nameservers": []any{"my.name.server"},
 		"must_staple":           "0",
 		"certificate_domain":    "foobar",
 		"private_key_pem":       "certkey",
@@ -76,12 +76,12 @@ func testACMECertificateStateData012V5() map[string]interface{} {
 	}
 }
 
-func testACMERegistrationStateData012V1() map[string]interface{} {
-	return map[string]interface{}{
+func testACMERegistrationStateData012V1() map[string]any {
+	return map[string]any{
 		"account_key_pem": "key",
 		"email_address":   "hello@localhost",
-		"external_account_binding": []interface{}{
-			map[string]interface{}{
+		"external_account_binding": []any{
+			map[string]any{
 				"key_id":      "kid",
 				"hmac_base64": "hmac",
 			},
@@ -91,15 +91,15 @@ func testACMERegistrationStateData012V1() map[string]interface{} {
 	}
 }
 
-func testACMERegistrationStateData012V2() map[string]interface{} {
-	return map[string]interface{}{
+func testACMERegistrationStateData012V2() map[string]any {
+	return map[string]any{
 		"account_key_pem":         "key",
 		"account_key_algorithm":   "ECDSA",
 		"account_key_ecdsa_curve": "P384",
 		"account_key_rsa_bits":    4096,
 		"email_address":           "hello@localhost",
-		"external_account_binding": []interface{}{
-			map[string]interface{}{
+		"external_account_binding": []any{
+			map[string]any{
 				"key_id":      "kid",
 				"hmac_base64": "hmac",
 			},
@@ -128,7 +128,7 @@ func TestResourceACMECertificateStateUpgraderV4Func(t *testing.T) {
 		t.Fatalf("error migrating state: %s", err)
 	}
 
-	ignore := cmpopts.IgnoreMapEntries(func(k string, _ interface{}) bool {
+	ignore := cmpopts.IgnoreMapEntries(func(k string, _ any) bool {
 		return k == "id"
 	})
 

--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -81,7 +81,7 @@ func saveACMERegistration(d *schema.ResourceData, reg *registration.Resource) er
 // If loadReg is supplied, the registration information is loaded in to the
 // user's registration, if it exists - if the account cannot be resolved by the
 // private key, then the appropriate error is returned.
-func expandACMEClient(d *schema.ResourceData, meta interface{}, loadReg bool) (*lego.Client, *acmeUser, error) {
+func expandACMEClient(d *schema.ResourceData, meta any, loadReg bool) (*lego.Client, *acmeUser, error) {
 	user, err := expandACMEUser(d)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting user data: %s", err.Error())
@@ -103,7 +103,7 @@ func expandACMEClient(d *schema.ResourceData, meta interface{}, loadReg bool) (*
 	return client, user, nil
 }
 
-func expandACMEClient_config(d *schema.ResourceData, meta interface{}, user registration.User) *lego.Config {
+func expandACMEClient_config(d *schema.ResourceData, meta any, user registration.User) *lego.Config {
 	config := lego.NewConfig(user)
 	config.CADirURL = meta.(*Config).ServerURL
 
@@ -126,9 +126,9 @@ func expandACMEClient_config(d *schema.ResourceData, meta interface{}, user regi
 // certificateResourceExpander is a simple interface to allow us to use the Get
 // function that is in ResourceData and ResourceDiff under the same function.
 type certificateResourceExpander interface {
-	Get(string) interface{}
-	GetOk(string) (interface{}, bool)
-	GetChange(string) (interface{}, interface{})
+	Get(string) any
+	GetOk(string) (any, bool)
+	GetChange(string) (any, any)
 }
 
 // expandCertificateResource takes saved state in the certificate resource
@@ -322,7 +322,7 @@ func parsePEMBundle(bundle []byte) ([]*x509.Certificate, error) {
 }
 
 // stringSlice converts an interface slice to a string slice.
-func stringSlice(src []interface{}) []string {
+func stringSlice(src []any) []string {
 	var dst []string
 	for _, v := range src {
 		dst = append(dst, v.(string))
@@ -375,7 +375,7 @@ func csrFromPEM(pemData []byte) (*x509.CertificateRequest, error) {
 }
 
 // validateKeyType validates a key_type resource parameter is correct.
-func validateKeyType(v interface{}, k string) (ws []string, errors []error) {
+func validateKeyType(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	found := false
 	for _, w := range []string{"P256", "P384", "2048", "4096", "8192"} {
@@ -393,8 +393,8 @@ func validateKeyType(v interface{}, k string) (ws []string, errors []error) {
 // validateDNSChallengeConfig ensures that the values supplied to the
 // dns_challenge resource parameter in the acme_certificate resource
 // are string values only.
-func validateDNSChallengeConfig(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(map[string]interface{})
+func validateDNSChallengeConfig(v any, k string) (ws []string, errors []error) {
+	value := v.(map[string]any)
 	bad := false
 	for _, w := range value {
 		switch w.(type) {
@@ -411,7 +411,7 @@ func validateDNSChallengeConfig(v interface{}, k string) (ws []string, errors []
 	return
 }
 
-func validateRevocationReason(v interface{}, k string) (ws []string, errors []error) {
+func validateRevocationReason(v any, k string) (ws []string, errors []error) {
 	value := RevocationReason(v.(string))
 	_, err := GetRevocationReason(value)
 	if err != nil {

--- a/acme/acme_structure_test.go
+++ b/acme/acme_structure_test.go
@@ -163,7 +163,7 @@ func blankCertificateResource() *schema.ResourceData {
 // registrationResourceData since it actually does a diff based on the
 // attributes in the schema, versus working with a blank ResourceData.
 func registrationResourceDataDefaultConfig(t *testing.T) *schema.ResourceData {
-	return schema.TestResourceDataRaw(t, resourceACMERegistration().Schema, make(map[string]interface{}))
+	return schema.TestResourceDataRaw(t, resourceACMERegistration().Schema, make(map[string]any))
 }
 
 // certificateResourceDataDefaultConfig returns the schema.ResourceData for a
@@ -179,7 +179,7 @@ func certificateResourceDataDefaultConfig(t *testing.T) *schema.ResourceData {
 	// able to differentiate between a schema that does not have this value in
 	// the client (registrations) versus one that does (certificates) as we can't
 	// test on the zero value for registrations.
-	return schema.TestResourceDataRaw(t, resourceACMECertificate().Schema, map[string]interface{}{"cert_timeout": 90})
+	return schema.TestResourceDataRaw(t, resourceACMECertificate().Schema, map[string]any{"cert_timeout": 90})
 }
 
 func TestACME_expandACMEUser(t *testing.T) {
@@ -340,7 +340,7 @@ func TestACME_validateKeyType_invalid(t *testing.T) {
 }
 
 func TestACME_validateDNSChallengeConfig(t *testing.T) {
-	m := map[string]interface{}{
+	m := map[string]any{
 		"AWS_FOO": "bar",
 	}
 
@@ -351,7 +351,7 @@ func TestACME_validateDNSChallengeConfig(t *testing.T) {
 }
 
 func TestACME_validateDNSChallengeConfig_invalid(t *testing.T) {
-	s := map[string]interface{}{
+	s := map[string]any{
 		"AWS_FOO": 1,
 	}
 

--- a/acme/certificate_challenges_test.go
+++ b/acme/certificate_challenges_test.go
@@ -22,8 +22,8 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 				r := resourceACMECertificate()
 				d := r.TestResourceData()
 
-				d.Set("dns_challenge", []interface{}{
-					map[string]interface{}{
+				d.Set("dns_challenge", []any{
+					map[string]any{
 						"provider": "route53",
 					},
 				})
@@ -40,10 +40,10 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 				r := resourceACMECertificate()
 				d := r.TestResourceData()
 
-				d.Set("dns_challenge", []interface{}{
-					map[string]interface{}{
+				d.Set("dns_challenge", []any{
+					map[string]any{
 						"provider": "exec",
-						"config": map[string]interface{}{
+						"config": map[string]any{
 							"EXEC_PATH": "exit 0",
 						},
 					},
@@ -62,10 +62,10 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 				r := resourceACMECertificate()
 				d := r.TestResourceData()
 
-				d.Set("dns_challenge", []interface{}{
-					map[string]interface{}{
+				d.Set("dns_challenge", []any{
+					map[string]any{
 						"provider": "exec",
-						"config": map[string]interface{}{
+						"config": map[string]any{
 							"EXEC_PATH":              "exit 0",
 							"EXEC_SEQUENCE_INTERVAL": "123",
 						},
@@ -85,13 +85,13 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 				r := resourceACMECertificate()
 				d := r.TestResourceData()
 
-				d.Set("dns_challenge", []interface{}{
-					map[string]interface{}{
+				d.Set("dns_challenge", []any{
+					map[string]any{
 						"provider": "route53",
 					},
-					map[string]interface{}{
+					map[string]any{
 						"provider": "exec",
-						"config": map[string]interface{}{
+						"config": map[string]any{
 							"EXEC_PATH": "exit 0",
 						},
 					},
@@ -110,17 +110,17 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 				r := resourceACMECertificate()
 				d := r.TestResourceData()
 
-				d.Set("dns_challenge", []interface{}{
-					map[string]interface{}{
+				d.Set("dns_challenge", []any{
+					map[string]any{
 						"provider": "exec",
-						"config": map[string]interface{}{
+						"config": map[string]any{
 							"EXEC_PATH":              "exit 0",
 							"EXEC_SEQUENCE_INTERVAL": "60", // explicit default
 						},
 					},
-					map[string]interface{}{
+					map[string]any{
 						"provider": "exec",
-						"config": map[string]interface{}{
+						"config": map[string]any{
 							"EXEC_PATH":              "exit 0",
 							"EXEC_SEQUENCE_INTERVAL": "123",
 						},
@@ -139,7 +139,7 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			got, gotClosers, err := expandDNSChallengeWrapperProvider(
 				tc.resourceData,
-				tc.resourceData.Get("dns_challenge").([]interface{}),
+				tc.resourceData.Get("dns_challenge").([]any),
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/acme/data_source_acme_server_url.go
+++ b/acme/data_source_acme_server_url.go
@@ -17,7 +17,7 @@ func dataSourceACMEServerURL() *schema.Resource {
 	}
 }
 
-func dataSourceACMEServerURLRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceACMEServerURLRead(d *schema.ResourceData, meta any) error {
 	d.SetId(meta.(*Config).ServerURL)
 	d.Set("server_url", meta.(*Config).ServerURL)
 	return nil

--- a/acme/dnsplugin/plugin.go
+++ b/acme/dnsplugin/plugin.go
@@ -52,7 +52,7 @@ func (p *DnsPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error 
 	return nil
 }
 
-func (p *DnsPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *DnsPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &DnsProviderClient{client: dnspluginproto.NewDNSProviderServiceClient(c)}, nil
 }
 

--- a/acme/provider.go
+++ b/acme/provider.go
@@ -35,7 +35,7 @@ type Config struct {
 	ServerURL string
 }
 
-func configureProvider(d *schema.ResourceData) (interface{}, error) {
+func configureProvider(d *schema.ResourceData) (any, error) {
 	return &Config{
 		ServerURL: d.Get("server_url").(string),
 	}, nil

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -626,10 +626,7 @@ func resourceACMECertificatePreCheckDelay(delay int) dns01.WrapPreCheckFunc {
 				if remaining < interval {
 					// To honor the specified timeout, make our next interval the
 					// time remaining. Minimum one second.
-					interval = remaining
-					if interval < 1 {
-						interval = 1
-					}
+					interval = max(remaining, 1)
 				}
 
 				log.Printf("[DEBUG] [%s] acme: Waiting an additional %d second(s) for DNS record propagation.", domain, remaining)

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -337,7 +337,7 @@ func resourceACMECertificateV5() *schema.Resource {
 	}
 }
 
-func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceACMECertificateCreate(d *schema.ResourceData, meta any) error {
 	// Pre-generate resource UUID here, in case there is a serious
 	// issue with UUID generation that would lead to inconsistency.
 	//
@@ -412,7 +412,7 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceACMECertificateRead(d, meta)
 }
 
-func resourceACMECertificateRead(d *schema.ResourceData, meta interface{}) error {
+func resourceACMECertificateRead(d *schema.ResourceData, meta any) error {
 	// This is a workaround to correct issues with some versions of the
 	// resource prior to 1.3.2 where a renewal failure would possibly
 	// delete the certificate.
@@ -447,11 +447,11 @@ func resourceACMECertificateRead(d *schema.ResourceData, meta interface{}) error
 
 // resourceACMECertificateCustomizeDiff checks the certificate for renewal and
 // flags it as NewComputed if it needs a renewal.
-func resourceACMECertificateCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func resourceACMECertificateCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	// Ensure duplicate providers for dns_challenge are not provided.
 	providerMap := make(map[string]bool)
-	for _, v := range d.Get("dns_challenge").([]interface{}) {
-		m := v.(map[string]interface{})
+	for _, v := range d.Get("dns_challenge").([]any) {
+		m := v.(map[string]any)
 		if v, ok := m["provider"]; ok && v.(string) != "" {
 			provider := v.(string)
 			if _, ok := providerMap[provider]; ok {
@@ -490,7 +490,7 @@ func resourceACMECertificateCustomizeDiff(_ context.Context, d *schema.ResourceD
 }
 
 // resourceACMECertificateUpdate renews a certificate if it has been flagged as changed.
-func resourceACMECertificateUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceACMECertificateUpdate(d *schema.ResourceData, meta any) error {
 	// We don't need to do anything else here if the certificate hasn't been diffed
 	expired, err := resourceACMECertificateHasExpired(d)
 	if err != nil {
@@ -541,7 +541,7 @@ func resourceACMECertificateUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 // resourceACMECertificateDelete "deletes" the certificate by revoking it.
-func resourceACMECertificateDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceACMECertificateDelete(d *schema.ResourceData, meta any) error {
 	if !d.Get("revoke_certificate_on_destroy").(bool) {
 		return nil
 	}

--- a/acme/resource_acme_registration.go
+++ b/acme/resource_acme_registration.go
@@ -104,7 +104,7 @@ func resourceACMERegistrationV2() *schema.Resource {
 	}
 }
 
-func resourceACMERegistrationCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceACMERegistrationCreate(d *schema.ResourceData, meta any) error {
 	// If we do not have a private key, create one.
 	if d.Get("account_key_pem").(string) == "" {
 		privateKeyPem, err := generatePrivateKey(
@@ -130,8 +130,8 @@ func resourceACMERegistrationCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("external_account_binding"); ok {
 		reg, err = client.Registration.RegisterWithExternalAccountBinding(registration.RegisterEABOptions{
 			TermsOfServiceAgreed: true,
-			Kid:                  v.([]interface{})[0].(map[string]interface{})["key_id"].(string),
-			HmacEncoded:          v.([]interface{})[0].(map[string]interface{})["hmac_base64"].(string),
+			Kid:                  v.([]any)[0].(map[string]any)["key_id"].(string),
+			HmacEncoded:          v.([]any)[0].(map[string]any)["hmac_base64"].(string),
 		})
 	} else {
 		// Normal registration.
@@ -154,7 +154,7 @@ func resourceACMERegistrationCreate(d *schema.ResourceData, meta interface{}) er
 	return saveACMERegistration(d, user.Registration)
 }
 
-func resourceACMERegistrationRead(d *schema.ResourceData, meta interface{}) error {
+func resourceACMERegistrationRead(d *schema.ResourceData, meta any) error {
 	_, user, err := expandACMEClient(d, meta, true)
 	if err != nil {
 		if regGone(err) {
@@ -169,7 +169,7 @@ func resourceACMERegistrationRead(d *schema.ResourceData, meta interface{}) erro
 	return saveACMERegistration(d, user.Registration)
 }
 
-func resourceACMERegistrationDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceACMERegistrationDelete(d *schema.ResourceData, meta any) error {
 	client, _, err := expandACMEClient(d, meta, true)
 	if err != nil {
 		return err

--- a/logger.go
+++ b/logger.go
@@ -26,18 +26,18 @@ func initLegoLogger() {
 	l.log("Messages from the lego library will show up as DEBUG messages.")
 }
 
-func (l *legoLogger) Fatal(args ...interface{})                 { l.log(args) }
-func (l *legoLogger) Fatalln(args ...interface{})               { l.log(args) }
-func (l *legoLogger) Fatalf(format string, args ...interface{}) { l.log(fmt.Sprintf(format, args...)) }
-func (l *legoLogger) Print(args ...interface{})                 { l.log(args) }
-func (l *legoLogger) Println(args ...interface{})               { l.log(args) }
-func (l *legoLogger) Printf(format string, args ...interface{}) { l.log(fmt.Sprintf(format, args...)) }
+func (l *legoLogger) Fatal(args ...any)                 { l.log(args) }
+func (l *legoLogger) Fatalln(args ...any)               { l.log(args) }
+func (l *legoLogger) Fatalf(format string, args ...any) { l.log(fmt.Sprintf(format, args...)) }
+func (l *legoLogger) Print(args ...any)                 { l.log(args) }
+func (l *legoLogger) Println(args ...any)               { l.log(args) }
+func (l *legoLogger) Printf(format string, args ...any) { l.log(fmt.Sprintf(format, args...)) }
 
 // log logs the raw message sent to it to the Terraform logger with a
 // prefix indicating it came from lego.
 //
 // All messages are logged at the debug level.
-func (l *legoLogger) log(args ...interface{}) {
+func (l *legoLogger) log(args ...any) {
 	// Strip any lego-based log level from the string. This should
 	// always be in the first argument.
 	if len(args) > 0 {
@@ -52,5 +52,5 @@ func (l *legoLogger) log(args ...interface{}) {
 		}
 	}
 
-	log.Println(append([]interface{}{"[DEBUG]", "lego:"}, args...)...)
+	log.Println(append([]any{"[DEBUG]", "lego:"}, args...)...)
 }


### PR DESCRIPTION
This is just an update to the codebase to clear out a bunch of linter warnings I had:

* Apply all modernize recommendations (mostly `interface{}` -> `any`)
* Add a `.golangci.yml` to the project to exclude errcheck (a notoriously noisy linter that unfortunately does not really conform to common patterns like Terraform's `d.Set()` et al, or `defer something.Close()`)