### PR TITLE
r/certificate: allow the use of ARI (ACME Renewal Information)

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -83,7 +83,7 @@ clean-pre-release:
 
 .PHONY: test
 test:
-	TF_LOG=debug TF_ACC=1 gotestsum --format=short-verbose $(TEST) $(TESTARGS)
+	TF_LOG=debug TF_ACC=1 gotestsum --format=short-verbose $(TEST) -timeout 20m $(TESTARGS)
 
 .PHONY: go-version-sync
 go-version-sync:

--- a/acme/acme_structure_test.go
+++ b/acme/acme_structure_test.go
@@ -245,7 +245,7 @@ func TestACME_expandACMEClient_badKey(t *testing.T) {
 
 func TestACME_certDaysRemaining_noCertData(t *testing.T) {
 	c := &certificate.Resource{}
-	_, err := certDaysRemaining(c)
+	_, err := certDaysRemaining(c, time.Now())
 	if err == nil {
 		t.Fatalf("expected error due to bad cert data")
 	}
@@ -276,7 +276,7 @@ func TestACME_certDaysRemaining_CACert(t *testing.T) {
 	c := &certificate.Resource{
 		Certificate: []byte(b),
 	}
-	_, err := certDaysRemaining(c)
+	_, err := certDaysRemaining(c, time.Now())
 	if err == nil {
 		t.Fatalf("expected error due to cert being a CA")
 	}

--- a/acme/lego_local.go
+++ b/acme/lego_local.go
@@ -1,0 +1,131 @@
+// Locally re-implemented lego functions.
+//
+// Code in this file has been adapted from the lego project
+// (https://go-acme.github.io/lego/), governed by the MIT license, the body
+// of which follows below:
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2024 Ludovic Fernandez
+// Copyright (c) 2015-2017 Sebastian Erhart
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package acme
+
+import (
+	"crypto"
+	"fmt"
+	"time"
+
+	"github.com/go-acme/lego/v4/certcrypto"
+	"github.com/go-acme/lego/v4/certificate"
+	"github.com/go-acme/lego/v4/log"
+)
+
+type localRenewOptions struct {
+	certificate.RenewOptions
+	UseARI bool
+}
+
+// renewWithOptions re-implements RenewWithOptions out of lego, with some
+// updates to allow for the ability to take a RenewalInfo ID.
+func renewWithOptions(
+	c *certificate.Certifier,
+	certRes certificate.Resource,
+	options localRenewOptions,
+) (*certificate.Resource, error) {
+	// Input certificate is PEM encoded.
+	// Decode it here as we may need the decoded cert later on in the renewal process.
+	// The input may be a bundle or a single certificate.
+	certificates, err := certcrypto.ParsePEMBundle(certRes.Certificate)
+	if err != nil {
+		return nil, err
+	}
+
+	x509Cert := certificates[0]
+	if x509Cert.IsCA {
+		return nil, fmt.Errorf("[%s] Certificate bundle starts with a CA certificate", certRes.Domain)
+	}
+
+	// This is just meant to be informal for the user.
+	timeLeft := x509Cert.NotAfter.Sub(time.Now().UTC())
+	log.Infof("[%s] acme: Trying renewal with %d hours remaining", certRes.Domain, int(timeLeft.Hours()))
+
+	// We always need to request a new certificate to renew.
+	// Start by checking to see if the certificate was based off a CSR,
+	// and use that if it's defined.
+	if len(certRes.CSR) > 0 {
+		csr, errP := certcrypto.PemDecodeTox509CSR(certRes.CSR)
+		if errP != nil {
+			return nil, errP
+		}
+
+		request := certificate.ObtainForCSRRequest{CSR: csr}
+
+		request.NotBefore = options.NotBefore
+		request.NotAfter = options.NotAfter
+		request.Bundle = options.Bundle
+		request.PreferredChain = options.PreferredChain
+		request.Profile = options.Profile
+		request.AlwaysDeactivateAuthorizations = options.AlwaysDeactivateAuthorizations
+
+		if options.UseARI {
+			var err error
+			request.ReplacesCertID, err = certificate.MakeARICertID(x509Cert)
+			if err != nil {
+				return nil, fmt.Errorf("error generating ARI cert ID: %w", err)
+			}
+		}
+
+		return c.ObtainForCSR(request)
+	}
+
+	var privateKey crypto.PrivateKey
+	if certRes.PrivateKey != nil {
+		privateKey, err = certcrypto.ParsePEMPrivateKey(certRes.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	request := certificate.ObtainRequest{
+		Domains:    certcrypto.ExtractDomains(x509Cert),
+		PrivateKey: privateKey,
+	}
+
+	request.MustStaple = options.MustStaple
+	request.NotBefore = options.NotBefore
+	request.NotAfter = options.NotAfter
+	request.Bundle = options.Bundle
+	request.PreferredChain = options.PreferredChain
+	request.EmailAddresses = options.EmailAddresses
+	request.Profile = options.Profile
+	request.AlwaysDeactivateAuthorizations = options.AlwaysDeactivateAuthorizations
+
+	if options.UseARI {
+		var err error
+		request.ReplacesCertID, err = certificate.MakeARICertID(x509Cert)
+		if err != nil {
+			return nil, fmt.Errorf("error generating ARI cert ID: %w", err)
+		}
+	}
+
+	return c.Obtain(request)
+}

--- a/build-support/scripts/pebble-start.sh
+++ b/build-support/scripts/pebble-start.sh
@@ -3,7 +3,7 @@
 set -e
 
 GOPATH="$(go env GOPATH)"
-PEBBLE_VERSION="2.8.0-vancluever3"
+PEBBLE_VERSION="2.8.0-vancluever4"
 # config files are relative to script dir
 PEBBLE_CFGFILE="../pebblecfg/basic.json"
 PEBBLE_PIDFILE="/tmp/pebble.pid"

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -184,6 +184,36 @@ provider can be configured correctly.
   expiration of a certificate before a renewal is attempted. The default is
   `30`. A value of less than `0` means that the certificate will never be
   renewed.
+* `use_renewal_info` (Optional) - When enabled, use information available from
+  the CA's ACME Renewal Information (ARI) endpoint for renewing certificates.
+  Default: `false`.
+
+-> More detail on ARI can be found in [RFC
+9773](https://datatracker.ietf.org/doc/rfc9773/).
+
+-> Note that `use_renewal_info` does not disable `min_days_remaining`! If the
+selected time within an ARI renewal window value cannot be reached at plan time
+(based on the current time plus the value of
+[`renewal_info_max_sleep`](#renewal_info_max_sleep)), or if the CA has no ARI
+endpoint, renewal behavior will fall back to comparing the certificate expiry
+time with the value in `min_days_remaining`. This means for short-lived
+certificates, you may wish to turn this value down so that the settings do not
+conflict; however, don't disable it altogether, as this may prevent the
+certificate from being renewed!
+
+* `renewal_info_max_sleep` (Optional) - The maximum amount of time, in seconds,
+  that the resource is willing to sleep during apply to reach a selected
+  renewal window time when `use_renewal_info` is set to `true`. Default: `0`.
+
+-> It's recommended to only use small values here (a few minutes maximum).
+Using extremely high values increases the risk of resource timeouts. To prevent
+hard resource timeouts, the maximum value allowed here is 900 seconds, or 15
+minutes.
+
+* `renewal_info_ignore_retry_after` (Optional) - Ignores the retry interval
+  supplied by the ARI endpoint for re-fetching renewal window data. Should only
+  be used for testing. Default: `false`.
+
 * `certificate_p12_password` - (Optional) Password to be used when generating
   the PFX file stored in [`certificate_p12`](#certificate_p12). Defaults to an
   empty string.
@@ -639,3 +669,15 @@ Refer to that field for the current URL of the certificate.
   RFC3339 format (`2006-01-02T15:04:05Z07:00`).
 * `certificate_serial` - The serial number, in string format, as reported by
   the CA.
+* `renewal_info_window_start` - The start of the discovered ARI renewal window
+  (see [`use_renewal_info`](#use_renewal_info)).
+* `renewal_info_window_end` - The end of the discovered ARI renewal window (see
+  [`use_renewal_info`](#use_renewal_info)).
+* `renewal_info_window_selected` - The selected time within the ARI renewal
+  window that a certificate will be renewed, if
+  [`use_renewal_info`](#use_renewal_info) is enabled.
+* `renewal_info_explanation_url` - A URL that can be optionally supplied by an
+  ARI endpoint explaining the renewal window policy (see
+  [`use_renewal_info`](#use_renewal_info)).
+* `renewal_info_retry_after` - A timestamp describing when ARI details will be
+  refreshed if already fetched (see [`use_renewal_info`](#use_renewal_info)).


### PR DESCRIPTION
This allows the ability to use ARI endpoints (ACME Renewal Information, RFC 9773) with the `acme_certificate` resource.

There are two settings (also a debug setting, not shown here but documented and also can be seen in the commit) that control this:

* The `use_renewal_info` setting, which controls whether or not ARI data is actually used (note that ARI details are always fetched, regardless of whether or not they are used).

* The `renewal_info_max_sleep` setting controls a sleep interval (configurable from 0-900 seconds) that allows setting a skew for determining whether or not a diff will be able to hit the selected ARI renewal time.

The ARI logic works like so: the renewal window for the certificate is fetched, saved, and a random time is selected within the renewal window, all in refresh. During diff time, if `use_renewal_info` is enabled and the selected renewal time can be reached through a combination of the current time and `renewal_info_max_sleep`, a certificate diff is
generated. Renewal then happens normally (with the addition of the specific fields that need to be set to tell the CA that the order is an ARI renewal, and is replacing a specific certificate), and the process resets.

In the event that the selected renewal time cannot be reached (either by it elapsing or through sleeping), or no ARI endpoint is found, renewal logic falls back to the more simple `min_days_remaining` check. This also prevents soft-locks due to expired certificates, as RFC-conforming ARI clients are not supposed to query endpoints for expired certificates. The main thing to note for consumers is that min_days_remaining may need to be tweaked for certificates with a window that reaches into the default 30-day min_days_remaining setting.