### PR TITLE
r/certificate: always deactivate authorizations after cert obtain

### DIFF
--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -303,6 +303,11 @@ func resourceACMECertificateV5() *schema.Resource {
 				Optional: true,
 				Default:  30,
 			},
+			"deactivate_authorizations": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"certificate_url": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -410,10 +415,11 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta any) error {
 			return err
 		}
 		cert, err = client.Certificate.ObtainForCSR(certificate.ObtainForCSRRequest{
-			CSR:            csr,
-			Bundle:         true,
-			PreferredChain: d.Get("preferred_chain").(string),
-			Profile:        d.Get("profile").(string),
+			CSR:                            csr,
+			Bundle:                         true,
+			PreferredChain:                 d.Get("preferred_chain").(string),
+			Profile:                        d.Get("profile").(string),
+			AlwaysDeactivateAuthorizations: d.Get("deactivate_authorizations").(bool),
 		})
 	} else {
 		domains := []string{}
@@ -431,11 +437,12 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta any) error {
 		}
 
 		cert, err = client.Certificate.Obtain(certificate.ObtainRequest{
-			Domains:        domains,
-			Bundle:         true,
-			MustStaple:     d.Get("must_staple").(bool),
-			PreferredChain: d.Get("preferred_chain").(string),
-			Profile:        d.Get("profile").(string),
+			Domains:                        domains,
+			Bundle:                         true,
+			MustStaple:                     d.Get("must_staple").(bool),
+			PreferredChain:                 d.Get("preferred_chain").(string),
+			Profile:                        d.Get("profile").(string),
+			AlwaysDeactivateAuthorizations: d.Get("deactivate_authorizations").(bool),
 		})
 	}
 
@@ -582,10 +589,11 @@ func resourceACMECertificateUpdate(d *schema.ResourceData, meta any) error {
 			*cert,
 			localRenewOptions{
 				RenewOptions: certificate.RenewOptions{
-					Bundle:         true,
-					PreferredChain: d.Get("preferred_chain").(string),
-					Profile:        d.Get("profile").(string),
-					MustStaple:     d.Get("must_staple").(bool),
+					Bundle:                         true,
+					PreferredChain:                 d.Get("preferred_chain").(string),
+					Profile:                        d.Get("profile").(string),
+					MustStaple:                     d.Get("must_staple").(bool),
+					AlwaysDeactivateAuthorizations: d.Get("deactivate_authorizations").(bool),
 				},
 				UseARI: d.Get("use_renewal_info").(bool),
 			},

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -264,6 +264,10 @@ By default, no reason provided in revocation requests. The reason is a string, w
 If you are looking to control timeouts related to a particular challenge (such
 as a DNS challenge), see that challenge provider's specific options.
 
+* `deactivate_authorizations` - Controls if authorizations are explicitly
+  deactivated after a certificate has been obtained, preventing their re-use.
+  Default: `true`.
+
 ### Using DNS challenges
 
 This method authenticates certificate domains by requiring the requester to


### PR DESCRIPTION
This adds a flag (enabled by default) that sets the certificate creation/renewal process to drop authorizations after a successful order.

Normally these authorizations linger for quite a while - on Let's Encrypt, this is 30 days for the classic profile and 7 hours for others. Presumably, this facilitates scenarios where it's useful for a challenge to not have to be fulfilled every time a certificate for a particular identifier is requested. However, from a principle of least privilege, it makes more sense to make sure that authorization is obtained on an as-needed basis. For example, this should help prevent instances where the key is compromised but access to the domain validation process was missing (e.g., no ability to change DNS records or access to a well-known HTTP endpoint).