### PR TITLE
feat: Add not_after attribute to allow certificate length selection.

### DIFF
--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -249,6 +249,12 @@ Pretend Pear X1`.
 -> Let's Encrypt publishes details on their profiles at
 <https://letsencrypt.org/docs/profiles/>.
 
+* `not_after` - (Optional) The desired expiration date of the certificate, in
+  RFC3339 format (`2006-01-02T15:04:05Z07:00`). This sets the `notAfter` field
+  in the ACME order, requesting that the CA issue a certificate that expires at
+  the specified time. Not all ACME CAs support this field. Changing this value
+  triggers a certificate renewal rather than a resource replacement.
+
 * `revoke_certificate_on_destroy` - Enables revocation of a certificate upon destroy,
 which includes when a resource is re-created. Default is `true`.
 


### PR DESCRIPTION
Google Public CA (and potentially others) supports notAfter field (RFC 8555) as an attribute. This PR just exposes the field that the upstream lego already supports.

This optional attribute allows users to request certificates with a specific expiration date, allowing short duration certificates. I use this to request <7 day certs.

- Schema: new `not_after` string attribute, validated as RFC3339
- Create: pass NotAfter to both ObtainForCSRRequest and ObtainRequest
- Renewal: pass NotAfter in RenewOptions; changes to `not_after` trigger in-place renewal rather than resource replacement
- CustomizeDiff: validate that not_after does not fall within min_days_remaining, which would cause perpetual renewals
- Docs: document the new attribute and its behavior