### PR TITLE
workflows: add Vouch workflow and public contribution notice

### DIFF
--- a/.github/workflows/vouch-check-pr.yml
+++ b/.github/workflows/vouch-check-pr.yml
@@ -1,0 +1,18 @@
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mitchellh/vouch/action/check-pr@v1
+        with:
+          pr-number: ${{ github.event.pull_request.number }}
+          auto-close: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Terraform ACME Provider Public Contribution Notice
+
+> [!NOTE]
+> **The short of it:** This project does not (any longer) accept public pull
+> requests. There are a few reasons for this, so read on if you want some
+> reasoning, or just feel free to [open an
+> issue](https://github.com/vancluever/terraform-provider-acme/issues/new/choose)
+> to get your specific problem or feature request looked at.
+
+The Terraform ACME provider is now closed to public pull requests. Any pull
+request opened will be closed using the
+[Vouch](https://github.com/mitchellh/vouch) workflow, with a message directing
+you to this document to explain why.
+
+Note that unlike other projects that might be implementing Vouch, it is
+unlikely I will be opening this project up to external contributors. If you
+have a feature request or bug, please open an issue to get further help.
+
+**Please do not use AI to open issues**. If you are using AI or an agent to
+understand an issue, take the time to comprehend the output and explain the
+issue **in your own words** before submitting.
+
+## Why?
+
+The Terraform ACME provider is a relatively small project that does not require
+much maintenance work to keep functional and up to date. While I have
+considered it to be largely feature complete for a long time, I am still
+interested in adding features and functionality if they make sense within the
+design of the provider.
+
+Performing this work myself allows me to continue to learn about new Terraform
+features, developments in the ACME specification and our upstream use of
+[lego](https://github.com/go-acme/lego), and steward the provider in a way that
+will not burn me out as a maintainer.
+
+The open source landscape has also changed significantly since this project has
+started, particularly recently due to the advent of AI coding tools and agents.
+Vouch has a [great section explaining
+this](https://github.com/mitchellh/vouch/blob/f0591095f3c46406301604874d2482797fab7bab/README.md#why).
+To add to this, on a personal level, I am not very interested in even having to
+engage with content created by AI coding agents and/or other tools (see last
+section). **This is not a blanket judgment of the work produced by such tools,
+or those that use them.** To each their own.
+
+## Open source, not open contribution
+
+This project is open source and distributed under the terms of the [Mozilla
+Public License](https://www.mozilla.org/en-US/MPL/2.0/). Open source, however
+does not necessarily mean open contribution, a point that seems to have been in
+discourse a lot recently due to the points made in the last paragraph of the
+previous section.
+
+Probably the best example of a closed-contribution project is SQLite, which has
+some great rationale and statements to this end on their [copyright
+page](https://www.sqlite.org/copyright.html). Echoing the sentiments
+particularly in the last part of that page, feature requests and proof of
+concepts are welcome, however I will more than likely implement all solutions
+to these personally. 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,15 @@ website][terraform-io] and the [GitHub project page][terraform-gh].
 Documentation for this provider can be found at
 https://registry.terraform.io/providers/vancluever/acme/latest/docs.
 
+## Contributing
+
+Note that public pull requests to this repository are closed. See
+[`CONTRIBUTING.md`](/CONTRIBUTING.md) for more details.
+
 ## License
 
 ```
-Copyright 2018-2025 Chris Marchesi
+Copyright 2018-2026 Chris Marchesi
 Copyright 2016-2018 PayByPhone Technologies, Inc.
 
 This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
This adds Vouch and a public contribution notice explaining that public pull requests are now closed.

## Why?

The Terraform ACME project was started nearly 10 years ago (as of this writing in February 2026), during a time when I was truly enthusiastic to learn and contribute to the Terraform project and ecosystem[^1]. Several things needed to be learned to do so: how to contribute to an existing provider, how to create a provider from scratch, how the ACME specification worked (e.g., actually reading RFC8555), and more. What exists here now is largely a proof of this learning.

From time to time, I've had the privilege of accepting contributions from those that I could trust had done enough of that learning as well in order to make meaningful contributions, and also coach them in doing what was needed to correct any shortcomings to the point that their contributions could be meaningful.

This worked because the artifacts (read: the code) created by said contributors served as proof of the work, and I could trust in the fact that those making contributions shared in these values as well, at least well enough to contribute. The advent of AI coding tools and agents has, unfortunately, broken that trust.

**This is not a blanket judgement of the work produced by such tools, or those that use them.** However, I am not interested in the song and dance of policing others' AI use through disclosure policies, giving feedback to those that are just going to feed it to an agent, or merging work from an agent that I could just be using myself if I so chose.

I'm also not interested in second guessing myself on whether or not this is actually happening when reviewing contributions, so this is the best recourse to ensure that I do not burn out maintaining the project.

This project is still being actively maintained and will continue to be done so indefinitely. It is, however, largely feature complete and does not require much upkeep. I will continue to review feature requests and will accept or reject them as to how I see them being a fit for the provider.

[^1]: The plan also *was* to make this for my current employer at the time, but we never ended up using it there. 😜
