### PR TITLE
r/certificate: fix saved certificate_not_before

### DIFF
--- a/acme/acme_structure.go
+++ b/acme/acme_structure.go
@@ -263,7 +263,7 @@ func splitPEMBundle(bundle []byte) (
 	}
 
 	cert = pem.EncodeToMemory(&pem.Block{Type: preambleCertificate, Bytes: cb[0].Raw})
-	certNotBefore = cb[0].NotAfter.Format(time.RFC3339)
+	certNotBefore = cb[0].NotBefore.Format(time.RFC3339)
 	certNotAfter = cb[0].NotAfter.Format(time.RFC3339)
 	certSerial = cb[0].SerialNumber.String()
 	issuer = make([]byte, 0)


### PR DESCRIPTION
Was added in #563 but I had a typo and added the appropriate tests after the fact, hoping that CI would catch it, but looks like the test result got lost in a few rebases and skipped jobs. :stuck_out_tongue: 