### PR TITLE
r/certificate: disable_complete_propagation -> disable_authoritative_propagation

### DIFF
--- a/acme/acme_migrations.go
+++ b/acme/acme_migrations.go
@@ -76,8 +76,7 @@ func resourceACMECertificateStateUpgraderV5Func(
 	}
 	result := z.(map[string]any)
 
-	oldKeyType, ok := rawState["key_type"]
-	if ok {
+	if oldKeyType, ok := rawState["key_type"]; ok {
 		switch oldKeyType.(string) {
 		case "2048":
 			result["key_type"] = certcrypto.RSA2048.String()
@@ -86,6 +85,11 @@ func resourceACMECertificateStateUpgraderV5Func(
 		case "8192":
 			result["key_type"] = certcrypto.RSA8192.String()
 		}
+	}
+
+	if disableCompletePropagation, ok := rawState["disable_complete_propagation"]; ok {
+		result["disable_authoritative_propagation"] = disableCompletePropagation
+		delete(result, "disable_complete_propagation")
 	}
 
 	return result, nil

--- a/acme/acme_migrations_test.go
+++ b/acme/acme_migrations_test.go
@@ -90,11 +90,13 @@ func testACMECertificateStateData012V6() map[string]any {
 			},
 		},
 		"recursive_nameservers": []any{"my.name.server"},
-		"must_staple":           "0",
-		"certificate_domain":    "foobar",
-		"private_key_pem":       "certkey",
-		"certificate_pem":       "certpem",
-		"certificate_url":       "certurl",
+		// NOTE: disable_complete_propagation added manually for v5 fixture in v5 -> v6 test
+		"disable_authoritative_propagation": "1",
+		"must_staple":                       "0",
+		"certificate_domain":                "foobar",
+		"private_key_pem":                   "certkey",
+		"certificate_pem":                   "certpem",
+		"certificate_url":                   "certurl",
 	}
 }
 
@@ -133,7 +135,9 @@ func testACMERegistrationStateData012V2() map[string]any {
 
 func TestResourceACMECertificateStateUpgraderV5Func(t *testing.T) {
 	expected := testACMECertificateStateData012V6()
-	actual, err := resourceACMECertificateStateUpgraderV5Func(context.TODO(), testACMECertificateStateData012V5(), nil)
+	v5State := testACMECertificateStateData012V5()
+	v5State["disable_complete_propagation"] = "1"
+	actual, err := resourceACMECertificateStateUpgraderV5Func(context.TODO(), v5State, nil)
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)
 	}

--- a/acme/certificate_challenges.go
+++ b/acme/certificate_challenges.go
@@ -191,7 +191,7 @@ func expandDNSChallenge(m map[string]any, nameServers []string) (dnsplugin.NewCl
 func expandDNSChallengeOptions(d *schema.ResourceData) []dns01.ChallengeOption {
 	var opts []dns01.ChallengeOption
 
-	if d.Get("disable_complete_propagation").(bool) {
+	if d.Get("disable_authoritative_propagation").(bool) {
 		opts = append(opts, dns01.DisableAuthoritativeNssPropagationRequirement())
 	}
 

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -289,7 +289,7 @@ func resourceACMECertificateV6() *schema.Resource {
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"disable_complete_propagation": {
+			"disable_authoritative_propagation": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -1376,7 +1376,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["www2.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1419,7 +1419,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["www2.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   revoke_certificate_reason = "superseded"
 
@@ -1476,7 +1476,7 @@ resource "acme_certificate" "certificate" {
   certificate_request_pem = "${tls_cert_request.req.cert_request_pem}"
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1531,7 +1531,7 @@ resource "acme_certificate" "certificate" {
 	certificate_request_pem = "${tls_cert_request.req.cert_request_pem}"
 
   recursive_nameservers        = ["%s"]
-	disable_complete_propagation = true
+	disable_authoritative_propagation = true
 	preferred_chain = "%s"
 
   dns_challenge {
@@ -1586,7 +1586,7 @@ resource "acme_certificate" "certificate" {
   min_days_remaining      = 1
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1629,7 +1629,7 @@ resource "acme_certificate" "certificate" {
   min_days_remaining = 18250
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1671,7 +1671,7 @@ resource "acme_certificate" "certificate" {
   common_name     = "*.${var.domain}"
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1719,7 +1719,7 @@ resource "acme_certificate" "certificate" {
   certificate_p12_password  = "${var.password}"
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1763,7 +1763,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["www15.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
   propagation_wait             = %d
 
   dns_challenge {
@@ -1808,7 +1808,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["www17.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
   pre_check_delay              = %d
 
   dns_challenge {
@@ -1853,7 +1853,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["test-dupe.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -1896,7 +1896,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["test-preferred2.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
   preferred_chain = "%s"
 
   dns_challenge {
@@ -2149,7 +2149,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["test-no-revoke2.${var.domain}"]
 
   recursive_nameservers         = ["%s"]
-  disable_complete_propagation  = true
+  disable_authoritative_propagation  = true
   revoke_certificate_on_destroy = false
 
   dns_challenge {
@@ -2191,7 +2191,7 @@ resource "acme_certificate" "certificate" {
   account_key_pem           = "${acme_registration.reg.account_key_pem}"
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -2233,7 +2233,7 @@ resource "acme_certificate" "certificate" {
   subject_alternative_names = ["www.${var.domain}"]
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -2277,7 +2277,7 @@ resource "acme_certificate" "certificate" {
   min_days_remaining        = 1
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -2322,7 +2322,7 @@ resource "acme_certificate" "certificate" {
   min_days_remaining        = %d
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -2371,7 +2371,7 @@ resource "acme_certificate" "certificate" {
 
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"
@@ -2420,7 +2420,7 @@ resource "acme_certificate" "certificate" {
 
 
   recursive_nameservers        = ["%s"]
-  disable_complete_propagation = true
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "exec"

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -129,12 +129,12 @@ case with the `classic` Let's Encrypt profile, the first domain defined in
   used to check for propagation of DNS challenge records, in addition to some
   in-provider checks such as zone detection. Defaults to your system-configured
   DNS resolvers.
-* `disable_complete_propagation` (Optional) - Disable the requirement for full
+* `disable_authoritative_propagation` (Optional) - Disable the requirement for authoritative
   propagation of the TXT challenge records before proceeding with validation.
   Defaults to `false`.
 
 -> See [About DNS propagation checks](#about-dns-propagation-checks) for details
-on the `recursive_nameservers`, `disable_complete_propagation`, and
+on the `recursive_nameservers`, `disable_authoritative_propagation`, and
 `propagation_wait` settings.
 
 * `pre_check_delay` (Optional) - Insert a delay after _every_ DNS challenge
@@ -152,7 +152,7 @@ configured (`common_name` + `subject_alternative_names`).
   wait).
 
 -> The wait is applied _per-domain_. When `propagation_wait` is set, propagation
-checks are skipped and `recursive_nameservers` / `disable_complete_propagation`
+checks are skipped and `recursive_nameservers` / `disable_authoritative_propagation`
 have no effect. `propagation_wait` conflicts with `pre_check_delay`.
 
 * `http_challenge` (Optional) - Defines an HTTP challenge to use in fulfilling
@@ -369,7 +369,7 @@ There are two parts to the DNS propagation check:
 -> The authoritative part of the DNS propagation check will almost always
 require access to the outside internet. Make sure you allow the required access
 accordingly, particularly in restricted networks. You can also use the
-`disable_complete_propagation` setting to bypass this check altogether (see
+`disable_authoritative_propagation` setting to bypass this check altogether (see
 below).
 
 The ACME provider will normally use your system-configured DNS resolvers to
@@ -397,7 +397,7 @@ resource "acme_certificate" "certificate" {
 
 Additionally, in air-gapped scenarios, internet access to DNS servers may not be
 available at all to the machine running Terraform. In this case, you can use
-`disable_complete_propagation` to bypass this authoritative DNS check, ensuring
+`disable_authoritative_propagation` to bypass this authoritative DNS check, ensuring
 that the only propagation check being done is on the system resolver or the
 resolver you configure with `recursive_nameservers`.
 
@@ -405,8 +405,8 @@ resolver you configure with `recursive_nameservers`.
 resource "acme_certificate" "certificate" {
   #...
 
-  recursive_nameservers        = ["8.8.8.8:53"]
-  disable_complete_propagation = true
+  recursive_nameservers             = ["8.8.8.8:53"]
+  disable_authoritative_propagation = true
 
   dns_challenge {
     provider = "route53"
@@ -416,7 +416,7 @@ resource "acme_certificate" "certificate" {
 }
 ```
 
-~> **NOTE:** When `disable_complete_propagation` is used, you can encounter
+~> **NOTE:** When `disable_authoritative_propagation` is used, you can encounter
 situations where the propagation check will pass before your platform has
 provisioned the DNS records on their name servers. Use this setting with care,
 such as in the aforementioned air-gapped scenario where the system running


### PR DESCRIPTION
This renames the `disable_complete_propagation` attribute to `disable_authoritative_propagation`, which should reflect the nature of the option better.