### PR TITLE
r/certificate: add match_domains for DNS challenges

### DIFF
--- a/acme/certificate_challenges.go
+++ b/acme/certificate_challenges.go
@@ -2,9 +2,11 @@ package acme
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-acme/lego/v5/challenge"
@@ -15,7 +17,6 @@ import (
 	"github.com/go-acme/lego/v5/providers/http/memcached"
 	"github.com/go-acme/lego/v5/providers/http/s3"
 	"github.com/go-acme/lego/v5/providers/http/webroot"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vancluever/terraform-provider-acme/v2/acme/dnsplugin"
 )
@@ -146,6 +147,11 @@ func expandDNSChallengeWrapperProvider(
 			expandRecursiveNameservers(d),
 		); err == nil {
 			dnsProvider.providers = append(dnsProvider.providers, result.Provider)
+			if matchDomains, ok := providerRaw.(map[string]any)["match_domains"]; ok {
+				dnsProvider.matchDomains = append(dnsProvider.matchDomains, stringSlice(matchDomains.([]any)))
+			} else {
+				dnsProvider.matchDomains = append(dnsProvider.matchDomains, []string{})
+			}
 			dnsClosers = append(dnsClosers, result.Closer)
 			if result.IsSequential {
 				isSequential = true
@@ -222,7 +228,14 @@ func expandRecursiveNameservers(d *schema.ResourceData) []string {
 // DNSProviderWrapper is a multi-provider wrapper to support multiple
 // DNS challenges.
 type DNSProviderWrapper struct {
-	providers []challenge.ProviderTimeout
+	providers             []challenge.ProviderTimeout
+	matchDomains          [][]string
+	providerDomainMatches map[string]providerDomainMatchEntry
+}
+
+type providerDomainMatchEntry struct {
+	providerIndexes []int
+	level           int
 }
 
 // NewDNSProviderWrapper returns an freshly initialized
@@ -233,28 +246,108 @@ func NewDNSProviderWrapper() (*DNSProviderWrapper, error) {
 
 // Present implements challenge.Provider for DNSProviderWrapper.
 func (d *DNSProviderWrapper) Present(ctx context.Context, domain, token, keyAuth string) error {
-	var err error
-	for _, p := range d.providers {
-		err = p.Present(ctx, domain, token, keyAuth)
+	d.filterMatches(domain)
+
+	if len(d.providerDomainMatches[domain].providerIndexes) == 0 {
+		return errors.New("none of the configured match_domains matched the domain")
+	}
+
+	var errs []error
+	for _, idx := range d.providerDomainMatches[domain].providerIndexes {
+		p := d.providers[idx]
+		err := p.Present(ctx, domain, token, keyAuth)
 		if err != nil {
-			err = multierror.Append(err, fmt.Errorf("error encountered while presenting token for DNS challenge: %s", err.Error()))
+			errs = append(
+				errs,
+				fmt.Errorf("error encountered while presenting token for DNS challenge: %w", err),
+			)
 		}
 	}
 
-	return err
+	return errors.Join(errs...)
+}
+
+func (d *DNSProviderWrapper) filterMatches(domain string) {
+	matchEntry := providerDomainMatchEntry{
+		providerIndexes: []int{},
+		level:           -1,
+	}
+	for providerIdx, patterns := range d.matchDomains {
+		if len(patterns) > 0 {
+			matchLevel := -1
+			for _, pattern := range patterns {
+				if level, matched := matchDomain(pattern, domain); matched && level > matchLevel {
+					matchLevel = level
+				}
+			}
+
+			switch {
+			case matchLevel < 0:
+				// No matches
+				continue
+			case matchLevel > matchEntry.level:
+				matchEntry.providerIndexes = []int{}
+				matchEntry.level = matchLevel
+				fallthrough
+			case matchLevel == matchEntry.level:
+				matchEntry.providerIndexes = append(matchEntry.providerIndexes, providerIdx)
+			}
+		} else if matchEntry.level <= 0 {
+			matchEntry.providerIndexes = append(matchEntry.providerIndexes, providerIdx)
+			matchEntry.level = 0
+		}
+	}
+
+	if d.providerDomainMatches == nil {
+		d.providerDomainMatches = make(map[string]providerDomainMatchEntry)
+	}
+
+	d.providerDomainMatches[domain] = matchEntry
+}
+
+func matchDomain(pattern, domain string) (int, bool) {
+	matchParts := reverseParts(pattern)
+	domainParts := reverseParts(domain)
+
+	for i := range matchParts {
+		if i >= len(domainParts) {
+			return 0, false
+		}
+
+		if !strings.EqualFold(matchParts[i], domainParts[i]) {
+			return 0, false
+		}
+	}
+
+	return len(matchParts), true
+}
+
+func reverseParts(domain string) []string {
+	parts := strings.Split(domain, ".")
+	result := make([]string, len(parts))
+	for i := range parts {
+		result[i] = parts[len(parts)-(i+1)]
+	}
+
+	return result
 }
 
 // CleanUp implements challenge.Provider for DNSProviderWrapper.
 func (d *DNSProviderWrapper) CleanUp(ctx context.Context, domain, token, keyAuth string) error {
-	var err error
-	for _, p := range d.providers {
-		err = p.CleanUp(ctx, domain, token, keyAuth)
+	var errs []error
+	// The map here should never not be initialized (initialized on present)
+	for _, idx := range d.providerDomainMatches[domain].providerIndexes {
+		p := d.providers[idx]
+		err := p.CleanUp(ctx, domain, token, keyAuth)
 		if err != nil {
-			err = multierror.Append(err, fmt.Errorf("error encountered while cleaning token for DNS challenge: %s", err.Error()))
+			errs = append(
+				errs,
+				fmt.Errorf("error encountered while cleaning token for DNS challenge: %w", err),
+			)
 		}
 	}
 
-	return err
+	return errors.Join(errs...)
 }
 
 // Timeout implements challenge.ProviderTimeout for

--- a/acme/certificate_challenges_test.go
+++ b/acme/certificate_challenges_test.go
@@ -1,6 +1,7 @@
 package acme
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -162,6 +163,196 @@ func TestExpandDNSChallengeWrapperProvider(t *testing.T) {
 
 			if tc.wantCloserLen != len(gotClosers) {
 				t.Fatalf("want closer len %d, got closer len %d", tc.wantCloserLen, len(gotClosers))
+			}
+		})
+	}
+}
+
+func TestACME_DNSProviderWrapper_matchDomains(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		pattern     string
+		domain      string
+		wantLevel   int
+		wantMatched bool
+	}{
+		{
+			desc:        "basic",
+			pattern:     "example.com",
+			domain:      "example.com",
+			wantLevel:   2,
+			wantMatched: true,
+		},
+		{
+			desc:        "mixed case",
+			pattern:     "exAmpLe.com",
+			domain:      "ExaMple.com",
+			wantLevel:   2,
+			wantMatched: true,
+		},
+		{
+			desc:        "basic exclusionary",
+			pattern:     "example.com",
+			domain:      "foo.com",
+			wantLevel:   0,
+			wantMatched: false,
+		},
+		{
+			desc:        "subdomain domain",
+			pattern:     "example.com",
+			domain:      "foo.example.com",
+			wantLevel:   2,
+			wantMatched: true,
+		},
+		{
+			desc:        "subdomain pattern (matching)",
+			pattern:     "foo.example.com",
+			domain:      "bar.foo.example.com",
+			wantLevel:   3,
+			wantMatched: true,
+		},
+		{
+			desc:        "subdomain pattern (not matching)",
+			pattern:     "foo.example.com",
+			domain:      "example.com",
+			wantLevel:   0,
+			wantMatched: false,
+		},
+		{
+			desc:        "wildcard domain",
+			pattern:     "example.com",
+			domain:      "*.example.com",
+			wantLevel:   2,
+			wantMatched: true,
+		},
+		{
+			// Note that this should be blocked in the validator (should not even be
+			// possible to use)
+			desc:        "wildcard pattern",
+			pattern:     "*.example.com",
+			domain:      "example.com",
+			wantLevel:   0,
+			wantMatched: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			gotLevel, gotMatched := matchDomain(tc.pattern, tc.domain)
+			if tc.wantLevel != gotLevel {
+				t.Fatalf("wanted level %d, got %d", tc.wantLevel, gotLevel)
+			}
+			if tc.wantMatched != gotMatched {
+				t.Fatalf("wanted matched %t, got %t", tc.wantMatched, gotMatched)
+			}
+		})
+	}
+}
+
+func TestACME_DNSProviderWrapper_filterMatches(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		domain       string
+		matchDomains [][]string
+		want         providerDomainMatchEntry
+	}{
+		{
+			desc:   "basic",
+			domain: "example.com",
+			matchDomains: [][]string{
+				{
+					"example.com",
+				},
+			},
+			want: providerDomainMatchEntry{
+				providerIndexes: []int{0},
+				level:           2,
+			},
+		},
+		{
+			desc:   "multi-list",
+			domain: "foo.bar.com",
+			matchDomains: [][]string{
+				{
+					"example.com",
+					"foo.bar.com",
+				},
+			},
+			want: providerDomainMatchEntry{
+				providerIndexes: []int{0},
+				level:           3,
+			},
+		},
+		{
+			desc:   "multi-provider",
+			domain: "bar.com",
+			matchDomains: [][]string{
+				{
+					"example.com",
+					"foo.bar.com",
+				},
+				{
+					"bar.com",
+				},
+			},
+			want: providerDomainMatchEntry{
+				providerIndexes: []int{1},
+				level:           2,
+			},
+		},
+		{
+			desc:   "provider override",
+			domain: "foo.bar.com",
+			matchDomains: [][]string{
+				{
+					"example.com",
+					"foo.bar.com",
+				},
+				{
+					"bar.com",
+				},
+				{
+					"foo.bar.com",
+				},
+			},
+			want: providerDomainMatchEntry{
+				providerIndexes: []int{0, 2},
+				level:           3,
+			},
+		},
+		{
+			desc:         "empty matches",
+			domain:       "foo.bar.com",
+			matchDomains: [][]string{{}},
+			want: providerDomainMatchEntry{
+				providerIndexes: []int{0},
+				level:           0,
+			},
+		},
+		{
+			desc:   "no matches",
+			domain: "example.com",
+			matchDomains: [][]string{
+				{
+					"foo.com",
+				},
+			},
+			want: providerDomainMatchEntry{
+				providerIndexes: []int{},
+				level:           -1,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			wrapper := &DNSProviderWrapper{
+				matchDomains: tc.matchDomains,
+			}
+
+			wrapper.filterMatches(tc.domain)
+
+			got := wrapper.providerDomainMatches[tc.domain]
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Errorf("want: %#v, got %#v", tc.want, got)
 			}
 		})
 	}

--- a/acme/helper_validations.go
+++ b/acme/helper_validations.go
@@ -1,9 +1,12 @@
 package acme
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
 // validateKeyType validates a key_type resource parameter is correct.
-func validateKeyType(v any, k string) (ws []string, errors []error) {
+func validateKeyType(v any, _ string) (ws []string, errors []error) {
 	value := v.(string)
 	found := false
 	for _, w := range []string{"P256", "P384", "RSA2048", "RSA4096", "RSA8192"} {
@@ -21,7 +24,7 @@ func validateKeyType(v any, k string) (ws []string, errors []error) {
 // validateDNSChallengeConfig ensures that the values supplied to the
 // dns_challenge resource parameter in the acme_certificate resource
 // are string values only.
-func validateDNSChallengeConfig(v any, k string) (ws []string, errors []error) {
+func validateDNSChallengeConfig(v any, _ string) (ws []string, errors []error) {
 	value := v.(map[string]any)
 	bad := false
 	for _, w := range value {
@@ -39,11 +42,23 @@ func validateDNSChallengeConfig(v any, k string) (ws []string, errors []error) {
 	return
 }
 
-func validateRevocationReason(v any, k string) (ws []string, errors []error) {
+func validateRevocationReason(v any, _ string) (ws []string, errors []error) {
 	value := RevocationReason(v.(string))
 	_, err := GetRevocationReason(value)
 	if err != nil {
 		errors = append(errors, err)
+	}
+	return
+}
+
+func validateMatchDomains(v any, _ string) (ws []string, errors []error) {
+	domainRegexp := regexp.MustCompile(`^([-a-zA-Z0-9]+\.)*[-a-zA-Z0-9]+$`)
+	value := stringSlice(v.([]any))
+	for _, w := range value {
+		if domainRegexp.Match([]byte(w)) {
+			continue
+		}
+		errors = append(errors, fmt.Errorf("invalid match domain pattern: %s", w))
 	}
 	return
 }

--- a/acme/helper_validations_test.go
+++ b/acme/helper_validations_test.go
@@ -1,0 +1,85 @@
+package acme
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestACME_validateKeyType(t *testing.T) {
+	s := "RSA2048"
+
+	_, errs := validateKeyType(s, "key_type")
+	if len(errs) > 0 {
+		t.Fatalf("bad: %#v", errs)
+	}
+}
+
+func TestACME_validateKeyType_invalid(t *testing.T) {
+	s := "512"
+
+	_, errs := validateKeyType(s, "key_type")
+	if len(errs) < 1 {
+		t.Fatalf("should have given an error")
+	}
+}
+
+func TestACME_validateDNSChallengeConfig(t *testing.T) {
+	m := map[string]any{
+		"AWS_FOO": "bar",
+	}
+
+	_, errs := validateDNSChallengeConfig(m, "config")
+	if len(errs) > 0 {
+		t.Fatalf("bad: %#v", errs)
+	}
+}
+
+func TestACME_validateDNSChallengeConfig_invalid(t *testing.T) {
+	s := map[string]any{
+		"AWS_FOO": 1,
+	}
+
+	_, errs := validateDNSChallengeConfig(s, "config")
+	if len(errs) < 1 {
+		t.Fatalf("should have given an error")
+	}
+}
+
+func TestACME_validateMatchDomains(t *testing.T) {
+	s := []any{
+		"example.com",
+		"foo.example.com",
+		"foo-bar.example.com",
+		"foo..example.com",
+		"com",
+		"com.",
+		"foo123.com",
+		"foo_123.com",
+	}
+
+	_, errs := validateMatchDomains(s, "match_domains")
+
+	expected := []error{
+		&comparableError{s: "invalid match domain pattern: foo..example.com"},
+		&comparableError{s: "invalid match domain pattern: com."},
+		&comparableError{s: "invalid match domain pattern: foo_123.com"},
+	}
+
+	if diff := cmp.Diff(expected, errs, cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("expected errors mismatch (-want +got):\n%s", diff)
+	}
+}
+
+type comparableError struct {
+	s string
+}
+
+func (e *comparableError) Error() string {
+	return e.s
+}
+
+func (e *comparableError) Is(target error) bool {
+	return e.s == target.Error()
+}

--- a/acme/helpers_test.go
+++ b/acme/helpers_test.go
@@ -348,46 +348,6 @@ func TestACME_splitPEMBundle_singleCert(t *testing.T) {
 	}
 }
 
-func TestACME_validateKeyType(t *testing.T) {
-	s := "RSA2048"
-
-	_, errs := validateKeyType(s, "key_type")
-	if len(errs) > 0 {
-		t.Fatalf("bad: %#v", errs)
-	}
-}
-
-func TestACME_validateKeyType_invalid(t *testing.T) {
-	s := "512"
-
-	_, errs := validateKeyType(s, "key_type")
-	if len(errs) < 1 {
-		t.Fatalf("should have given an error")
-	}
-}
-
-func TestACME_validateDNSChallengeConfig(t *testing.T) {
-	m := map[string]any{
-		"AWS_FOO": "bar",
-	}
-
-	_, errs := validateDNSChallengeConfig(m, "config")
-	if len(errs) > 0 {
-		t.Fatalf("bad: %#v", errs)
-	}
-}
-
-func TestACME_validateDNSChallengeConfig_invalid(t *testing.T) {
-	s := map[string]any{
-		"AWS_FOO": 1,
-	}
-
-	_, errs := validateDNSChallengeConfig(s, "config")
-	if len(errs) < 1 {
-		t.Fatalf("should have given an error")
-	}
-}
-
 func TestExpandACMEClient_config_certTimeout_default(t *testing.T) {
 	testCases := []struct {
 		desc     string

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -140,6 +140,11 @@ func resourceACMECertificateV6() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"match_domains": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
 						"config": {
 							Type:         schema.TypeMap,
 							Optional:     true,
@@ -522,17 +527,20 @@ func resourceACMECertificateRead(d *schema.ResourceData, meta any) error {
 // resourceACMECertificateCustomizeDiff checks the certificate for renewal and
 // flags it as NewComputed if it needs a renewal.
 func resourceACMECertificateCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
-	// Ensure duplicate providers for dns_challenge are not provided.
-	providerMap := make(map[string]bool)
+	// Validate dns_challenge blocks (match_domains and ensuring that the
+	// "provider" key is defined)
 	for _, v := range d.Get("dns_challenge").([]any) {
 		m := v.(map[string]any)
 		if v, ok := m["provider"]; ok && v.(string) != "" {
 			provider := v.(string)
-			if _, ok := providerMap[provider]; ok {
-				return fmt.Errorf("duplicate dns_challenge providers: %s", provider)
+			_, errs := validateMatchDomains(m["match_domains"], "match_domains")
+			if len(errs) > 0 {
+				return fmt.Errorf(
+					"invalid match_domains for DNS provider %s: %w",
+					provider,
+					errors.Join(errs...),
+				)
 			}
-
-			providerMap[provider] = true
 		} else {
 			return fmt.Errorf("DNS challenge provider not defined")
 		}

--- a/acme/resource_acme_certificate_test.go
+++ b/acme/resource_acme_certificate_test.go
@@ -841,6 +841,77 @@ func TestAccACMECertificate_validityDays_validation(t *testing.T) {
 	})
 }
 
+func TestAccACMECertificate_matchDomains(t *testing.T) {
+	wantEnv := os.Environ()
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		CheckDestroy:      testAccCheckACMECertificateStatus("acme_certificate.certificate", certificateStatusRevoked),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigMatchDomains(configMatchDomainsTypeValid),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "www", "www2"),
+					testAccCheckACMECertificateIntermediateEqual("acme_certificate.certificate", getPebbleCertificate(mainIntermediateURL)),
+					testAccCheckACMECertificateStatus("acme_certificate.certificate", certificateStatusValid),
+					testAccCheckEnvironNotChanged(wantEnv),
+				),
+			},
+		},
+	})
+}
+
+func TestAccACMECertificate_matchDomains_split(t *testing.T) {
+	wantEnv := os.Environ()
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		CheckDestroy:      testAccCheckACMECertificateStatus("acme_certificate.certificate", certificateStatusRevoked),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccACMECertificateConfigMatchDomainsSplit(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "id", uuidRegexp),
+					resource.TestMatchResourceAttr("acme_certificate.certificate", "certificate_url", certURLRegexp),
+					testAccCheckACMECertificateValid("acme_certificate.certificate", "www", "www2"),
+					testAccCheckACMECertificateIntermediateEqual("acme_certificate.certificate", getPebbleCertificate(mainIntermediateURL)),
+					testAccCheckACMECertificateStatus("acme_certificate.certificate", certificateStatusValid),
+					testAccCheckEnvironNotChanged(wantEnv),
+				),
+			},
+		},
+	})
+}
+
+func TestAccACMECertificate_matchDomains_noMatch(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccACMECertificateConfigMatchDomains(configMatchDomainsTypeNonMatching),
+				ExpectError: regexp.MustCompile("none of the configured match_domains matched the domain"),
+			},
+		},
+	})
+}
+
+func TestAccACMECertificate_matchDomains_invalidDomain(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		ExternalProviders: testAccExternalProviders,
+		CheckDestroy:      testAccCheckACMECertificateStatus("acme_certificate.certificate", certificateStatusRevoked),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccACMECertificateConfigMatchDomains(configMatchDomainsTypeInvalid),
+				ExpectError: regexp.MustCompile("invalid match_domains for DNS provider"),
+			},
+		},
+	})
+}
+
 type testAccCheckACMECertificateStandardOpts struct {
 	CommonName             string
 	SubjectAlternativeName string
@@ -2436,6 +2507,123 @@ resource "acme_certificate" "certificate" {
 		pebbleCertDomain,
 		validityDays,
 		pebbleChallTestDNSSrv,
+		pebbleChallTestDNSScriptPath,
+	)
+}
+
+type configMatchDomainsType int
+
+const (
+	configMatchDomainsTypeInvalid = iota
+	configMatchDomainsTypeValid
+	configMatchDomainsTypeNonMatching
+)
+
+func testAccACMECertificateConfigMatchDomains(valid configMatchDomainsType) string {
+	var matchDomainValue string
+	switch valid {
+	case configMatchDomainsTypeInvalid:
+		matchDomainValue = "com."
+	case configMatchDomainsTypeValid:
+		matchDomainValue = "${var.domain}"
+	case configMatchDomainsTypeNonMatching:
+		matchDomainValue = "this.should.never.be.used." + pebbleCertDomain
+	}
+
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+variable "email_address" {
+  default = "nobody@%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "acme_registration" "reg" {
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "www.${var.domain}"
+  subject_alternative_names = ["www2.${var.domain}"]
+
+  recursive_nameservers             = ["%s"]
+  disable_authoritative_propagation = true
+
+  dns_challenge {
+    provider = "exec"
+    match_domains = ["%s"]
+    config = {
+      EXEC_PATH = "%s"
+      EXEC_SEQUENCE_INTERVAL = "5"
+    }
+  }
+}
+`,
+		pebbleDirBasic,
+		pebbleCertDomain,
+		pebbleCertDomain,
+		pebbleChallTestDNSSrv,
+		matchDomainValue,
+		pebbleChallTestDNSScriptPath,
+	)
+}
+
+func testAccACMECertificateConfigMatchDomainsSplit() string {
+	return fmt.Sprintf(`
+provider "acme" {
+  server_url = "%s"
+}
+
+variable "email_address" {
+  default = "nobody@%s"
+}
+
+variable "domain" {
+  default = "%s"
+}
+
+resource "acme_registration" "reg" {
+  email_address   = "${var.email_address}"
+}
+
+resource "acme_certificate" "certificate" {
+  account_key_pem           = "${acme_registration.reg.account_key_pem}"
+  common_name               = "www.${var.domain}"
+  subject_alternative_names = ["www2.${var.domain}"]
+
+  recursive_nameservers             = ["%s"]
+  disable_authoritative_propagation = true
+
+  dns_challenge {
+    provider = "exec"
+    match_domains = ["www.${var.domain}"]
+    config = {
+      EXEC_PATH = "%s"
+      EXEC_SEQUENCE_INTERVAL = "5"
+    }
+  }
+
+  dns_challenge {
+    provider = "exec"
+    match_domains = ["www2.${var.domain}"]
+    config = {
+      EXEC_PATH = "%s"
+      EXEC_SEQUENCE_INTERVAL = "5"
+    }
+  }
+}
+`,
+		pebbleDirBasic,
+		pebbleCertDomain,
+		pebbleCertDomain,
+		pebbleChallTestDNSSrv,
+		pebbleChallTestDNSScriptPath,
 		pebbleChallTestDNSScriptPath,
 	)
 }

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -334,6 +334,62 @@ resource "acme_certificate" "certificate" {
 }
 ```
 
+#### Restricting a challenge to specific domains
+
+You may use the `match_domains` argument within a `dns_challenge` block to
+restrict a challenge provider to a specific domain or set of domains only. This
+argument takes a list of strings, filtering domains presented to it with said
+list and only adding challenge records for matching domains.
+
+resource "acme_certificate" "certificate" {
+  common_name               = "example.com"
+  subject_alternative_names = ["one.foo.example.com", "two.foo.example.com"]
+
+  #...
+
+  dns_challenge {
+    provider = "route53"
+    match_domains = ["example.com"]
+
+    config = {
+      AWS_ACCESS_KEY_ID     = var.aws_access_key_main
+      AWS_SECRET_ACCESS_KEY = var.aws_secret_key_main
+      AWS_SESSION_TOKEN     = var.aws_security_token_main
+      #...
+    }
+  }
+
+  dns_challenge {
+    provider = "route53"
+    match_domains = ["foo.example.com"]
+
+    config = {
+      AWS_ACCESS_KEY_ID     = var.aws_access_key_foo
+      AWS_SECRET_ACCESS_KEY = var.aws_secret_key_foo
+      AWS_SESSION_TOKEN     = var.aws_security_token_foo
+      #...
+    }
+  }
+
+  #...
+}
+
+Note that the following rules apply to the `match_domains` argument: 
+
+* Domains must be valid domain name characters (letters, numbers, dashes, and
+  dots). Wildcard characters are not allowed (wildcard domains are matched as
+  if the `*` was the level above the matched domain, e.g., `example.com`
+  matches `*.example.com`).
+* Domains do not end in a period (`.`), e.g., all domains are considered fully
+  qualified without them.
+* Dots must correctly delimit subdomains, e.g., `exmaple..com` or `.com` are
+  invalid.
+* Any challenge providers with a `match_domains` argument must match at least
+  one domain in the certificate.
+* Providers with a match on a higher-level subdomain (e.g., `foo.example.com`
+  above) replace any match on a lower level, overriding matches on a lower
+  level.
+
 #### Using Variable Files for Provider Arguments
 
 Most provider arguments can be suffixed with `_FILE` to specify that you wish to


### PR DESCRIPTION
This allows DNS challenges to be filtered according to domain.

The functionality works as follows:

* `match_domains` in the challenge entry can be defined to a set of domain entries.
* Domains match according to their subdomain level.
* Deeper subdomain levels take priority, e.g., providers filtering on `foo.example.com` will supersede providers filtering on `example.com` for matching domains.
* Providers with no filters match all domains on subdomain level 0; these providers will be superseded by any provider with a defined matching filter.