### PR TITLE
r/certificate: do not use lego client for ARI

### DIFF
--- a/acme/helper_client.go
+++ b/acme/helper_client.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto"
 	"fmt"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/go-acme/lego/v5/acme"
@@ -86,6 +88,7 @@ func expandACMEClient(d *schema.ResourceData, meta any, loadReg bool) (*lego.Cli
 func expandACMEClient_config(d *schema.ResourceData, meta any, user registration.User) *lego.Config {
 	config := lego.NewConfig(user)
 	config.CADirURL = meta.(*Config).ServerURL
+	config.UserAgent = formatUserAgentShort()
 
 	// Note this function is used by both the registration and certificate
 	// resources, but cert timeout is not necessary during registration, so it's
@@ -95,4 +98,14 @@ func expandACMEClient_config(d *schema.ResourceData, meta any, user registration
 	}
 
 	return config
+}
+
+func formatUserAgentShort() string {
+	return "terraform-provider-acme" + "/" + ReleaseVersion
+}
+
+// FormatUserAgentLong returns a agent for use in client requests, we also use
+// it in the -version command for the plugin.
+func FormatUserAgentLong() string {
+	return strings.TrimSpace(fmt.Sprintf("%s (%s; %s)", formatUserAgentShort(), runtime.GOOS, runtime.GOARCH))
 }

--- a/acme/lego_local.go
+++ b/acme/lego_local.go
@@ -32,13 +32,22 @@ package acme
 import (
 	"context"
 	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/go-acme/lego/v5/acme"
 	"github.com/go-acme/lego/v5/acme/api"
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/certificate"
+	"github.com/go-acme/lego/v5/lego"
 	"github.com/go-acme/lego/v5/log"
 )
 
@@ -140,4 +149,134 @@ func renewWithOptions(
 	}
 
 	return c.Obtain(context.TODO(), request)
+}
+
+// getCertificateARIRenewalInfo is a client-less function that can fetch the
+// ARI information for a specific certificate at a specific ACME directory URL.
+//
+// ARI does not require authentication, e.g., requests to the endpoint do not
+// need to be signed, so this helps facilitate this by just allowing a lookup
+// without the standard lego.Client.
+func getCertificateARIRenewalInfo(dirURL string, cert *x509.Certificate) (*acme.ExtendedRenewalInfo, error) {
+	certID, err := api.MakeARICertID(cert)
+	if err != nil {
+		return nil, fmt.Errorf("error making certID: %w", err)
+	}
+
+	client := createDefaultARIHTTPClient()
+
+	ariURL, err := ariEndpointForDirectory(client, dirURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting ARI URL: %w", err)
+	}
+
+	return getCertificateARIRenewalInfoInner(client, ariURL, certID)
+}
+
+// ariEndpointForDirectory is a client-less function that can fetch the ARI
+// endpoint for an ACME directory.
+//
+// ARI does not require authentication, e.g., requests to the endpoint do not
+// need to be signed, so this helps facilitate this by just allowing a lookup
+// without the standard lego.Client.
+func ariEndpointForDirectory(client *http.Client, dirURL string) (string, error) {
+	resp, err := doGetRequest(client, dirURL)
+	if err != nil {
+		return "", fmt.Errorf("directory request failed: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	var resultRaw struct {
+		RenewalInfo string `json:"renewalInfo"`
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&resultRaw); err != nil {
+		return "", fmt.Errorf("failed to read directory response body: %w", err)
+	}
+
+	return resultRaw.RenewalInfo, nil
+}
+
+// getCertificateARIRenewalInfoInner is just the inner request to the ARI
+// endpoint from ariEndpointForDirectory.
+func getCertificateARIRenewalInfoInner(
+	client *http.Client,
+	ariURL string,
+	ariCertID string,
+) (*acme.ExtendedRenewalInfo, error) {
+	resp, err := doGetRequest(client, ariURL+"/"+ariCertID)
+	if err != nil {
+		return nil, fmt.Errorf("ARI request failed: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	result := new(acme.ExtendedRenewalInfo)
+
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to read ARI response body: %w", err)
+	}
+
+	return result, nil
+}
+
+// Note that the client bits are cribbed from lego pretty much directly, so
+// that we can mirror what they do.
+
+const (
+	caCertificatesEnvVar = "LEGO_CA_CERTIFICATES"
+	caSystemCertPool     = "LEGO_CA_SYSTEM_CERT_POOL"
+	caServerNameEnvVar   = "LEGO_CA_SERVER_NAME"
+)
+
+func createDefaultARIHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: 2 * time.Minute,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			TLSClientConfig: &tls.Config{
+				ServerName: os.Getenv(caServerNameEnvVar),
+				RootCAs:    initCertPool(),
+			},
+		},
+	}
+}
+
+func initCertPool() *x509.CertPool {
+	customCACertsPath := os.Getenv(caCertificatesEnvVar)
+	if customCACertsPath == "" {
+		return nil
+	}
+
+	useSystemCertPool, _ := strconv.ParseBool(os.Getenv(caSystemCertPool))
+
+	caCerts := strings.Split(customCACertsPath, string(os.PathListSeparator))
+
+	certPool, err := lego.CreateCertPool(caCerts, useSystemCertPool)
+	if err != nil {
+		panic(fmt.Sprintf("create certificates pool: %v", err))
+	}
+
+	return certPool
+}
+
+// Run up a GET request with the user-agent set.
+func doGetRequest(client *http.Client, reqURL string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", FormatUserAgentLong())
+
+	return client.Do(req)
 }

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-acme/lego/v5/certcrypto"
 	"github.com/go-acme/lego/v5/certificate"
 	"github.com/go-acme/lego/v5/challenge/dns01"
-	"github.com/go-acme/lego/v5/lego"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -502,11 +501,6 @@ func resourceACMECertificateCreate(d *schema.ResourceData, meta any) error {
 }
 
 func resourceACMECertificateRead(d *schema.ResourceData, meta any) error {
-	client, _, err := expandACMEClient(d, meta, true)
-	if err != nil {
-		return err
-	}
-
 	if _, ok := d.GetOk("certificate_pem"); !ok {
 		// If we can't find the certificate, just force a new one. This used to
 		// recover from the API to correct an issue prior to v1.3.2. This is very
@@ -517,7 +511,8 @@ func resourceACMECertificateRead(d *schema.ResourceData, meta any) error {
 		return nil
 	}
 
-	if err := resourceACMECertificateRenewalInfoRefresh(d, client, time.Now()); err != nil {
+	dirURL := meta.(*Config).ServerURL
+	if err := resourceACMECertificateRenewalInfoRefresh(d, dirURL, time.Now()); err != nil {
 		return err
 	}
 
@@ -839,7 +834,7 @@ func GetRevocationReason(reason RevocationReason) (uint, error) {
 
 func resourceACMECertificateRenewalInfoRefresh(
 	d *schema.ResourceData,
-	client *lego.Client,
+	dirURL string,
 	now time.Time,
 ) error {
 	// Check to see if we have a retry-after response, if we do, honor it
@@ -877,7 +872,7 @@ func resourceACMECertificateRenewalInfoRefresh(
 		return nil
 	}
 
-	renewalInfoResp, err := client.Certificate.GetRenewalInfo(context.TODO(), cert)
+	renewalInfoResp, err := getCertificateARIRenewalInfo(dirURL, cert)
 	if err != nil {
 		if errors.Is(err, api.ErrNoARI) {
 			// No ARI detail, set blank values and return

--- a/acme/version.go
+++ b/acme/version.go
@@ -1,0 +1,8 @@
+// written by write-releaseversion.sh - DO NOT EDIT
+
+package acme
+
+const (
+	VersionArg     = "-version"
+	ReleaseVersion = "3.0.0"
+)

--- a/build-support/scripts/release.sh
+++ b/build-support/scripts/release.sh
@@ -65,13 +65,17 @@ fi
 
 set -e
 
+# update acme/version.go if needed
+message begin "==> Update release version generated code (if needed) <=="
+./build-support/scripts/write-releaseversion.sh
+
 # Timestamp and update version in changelog
 message begin "==> Timetsamping current release in CHANGELOG.md <=="
 current_date="$(date "+%B %e, %Y" | sed -E -e 's/  / /')"
 echo -e "## ${release} (${current_date})\n$(tail -n +2 CHANGELOG.md)" > CHANGELOG.md
 
-message begin "==> Committing CHANGELOG.md <=="
-git add CHANGELOG.md
+message begin "==> Committing release <=="
+git add CHANGELOG.md acme/version.go
 git commit -m "$(echo -e "Release v${release}\n\nSee CHANGELOG.md for more details.")"
 
 message begin "==> Tagging Release v${release} <=="
@@ -87,9 +91,10 @@ new_prerelease="${semver[0]}.${semver[1]}.$((semver[2]+1))-pre"
 
 message begin "==> Bumping CHANGELOG.md to Release v${new_prerelease} <=="
 echo -e "## ${new_prerelease} (Unreleased)\n\nBumped version for dev.\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+./build-support/scripts/write-releaseversion.sh
 
-git add CHANGELOG.md
-git commit -m "Bump CHANGELOG.md to v${new_prerelease}"
+git add CHANGELOG.md acme/version.go
+git commit -m "Bump version to v${new_prerelease}"
 
 message begin "==> Pushing Commits and Tags <=="
 git push origin "$(git ls-remote --symref origin HEAD | head -n1 | awk '{print $2}')"

--- a/build-support/scripts/write-releaseversion.sh
+++ b/build-support/scripts/write-releaseversion.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+if ! [ -f "CHANGELOG.md" ]; then
+  echo -e "error: CHANGELOG.md not found in current directory" 1>&2
+  exit 1
+fi
+
+if ! [ -f "acme/version.go" ]; then
+  echo -e "error: acme/version.go not found, please run this from project root" 1>&2
+  exit 1
+fi
+
+release=$(head -n 1 CHANGELOG.md | awk '{print $2}')
+IFS="." read -r -a semver <<< "${release}"
+major="${semver[0]}"
+minor="${semver[1]}"
+IFS="-+" read -r -a patchpremeta <<< "${semver[2]}"
+patch="${patchpremeta[0]}"
+
+for x in "${major}" "${minor}" "${patch}"; do 
+  if ! [ "${x}" -eq "${x}" ]; then
+    echo -e "${release} is not a proper semantic-versioned release." 1>&2
+    echo -e "Please update the first line in CHANGELOG.md to a numeric MAJOR.MINOR.PATCH version." 1>&2
+    exit 1
+  fi
+done
+
+cat > acme/version.go <<EOS
+// written by write-releaseversion.sh - DO NOT EDIT
+
+package acme
+
+const (
+	VersionArg     = "-version"
+	ReleaseVersion = "${release}"
+)
+EOS

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
@@ -9,7 +10,9 @@ import (
 )
 
 func main() {
-	if len(os.Args) == 2 && os.Args[1] == dnsplugin.PluginArg {
+	if len(os.Args) == 2 && os.Args[1] == acme.VersionArg {
+		fmt.Fprintln(os.Stderr, acme.FormatUserAgentLong())
+	} else if len(os.Args) == 2 && os.Args[1] == dnsplugin.PluginArg {
 		// Start the plugin here
 		dnsplugin.Serve()
 	} else {


### PR DESCRIPTION
This removes the use of the lego client for fetching ARI details. This allows us to make requests for these unautheticated, as per RFC 9773.

This commit also includes additional scaffolding to make this happen, including the addition of a versioned User-Agent that is used in the ARI requests, and passed to the lego client.