### PR TITLE
r/certificate: activate schema V7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 3.1.1-pre (Unreleased)
 
-Bumped version for dev.
+BUG FIXES:
+
+The bug fix that was a part of 3.0.1, which was effectively not enabled due to
+the new schema not being activated in the resource, should now be effected in
+this version. See the notes for 3.0.1 for more details.
 
 ## 3.1.0 (September 4, 2026)
 

--- a/acme/resource_acme_certificate.go
+++ b/acme/resource_acme_certificate.go
@@ -38,7 +38,7 @@ const (
 // resourceACMECertificate returns the current version of the
 // acme_registration resource and needs to be updated when the schema
 // version is incremented.
-func resourceACMECertificate() *schema.Resource { return resourceACMECertificateV6() }
+func resourceACMECertificate() *schema.Resource { return resourceACMECertificateV7() }
 
 func resourceACMECertificateV7() *schema.Resource {
 	return &schema.Resource{


### PR DESCRIPTION
This was added in #623 but not activated, effectively keeping the broken ECDSA key types.